### PR TITLE
add tests commenting logic we need to test for and cpi crates for loopscale / orca

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,30 +4,30 @@ version = 4
 
 [[package]]
 name = "aead"
-version = "0.5.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
 dependencies = [
- "crypto-common",
  "generic-array",
 ]
 
 [[package]]
 name = "aes"
-version = "0.8.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
+ "opaque-debug",
 ]
 
 [[package]]
 name = "aes-gcm-siv"
-version = "0.11.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae0784134ba9375416d469ec31e7c5f9fa94405049cf08c5ce5b4698be673e0d"
+checksum = "589c637f0e68c877bbd59a4599bbe849cac8e5f3e4b5a3ebae8f528cd218dcdc"
 dependencies = [
  "aead",
  "aes",
@@ -40,11 +40,23 @@ dependencies = [
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.15",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
  "zerocopy 0.7.35",
@@ -61,9 +73,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-access-control"
-version = "0.31.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37013051defd745a5437d6842bd404e5480e14ad4e4f0441dd9a81a4b9aea1d6"
+checksum = "47fe28365b33e8334dd70ae2f34a43892363012fe239cf37d2ee91693575b1f8"
 dependencies = [
  "anchor-syn",
  "proc-macro2",
@@ -73,12 +85,12 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-account"
-version = "0.31.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92db0f793e924e18462b3fac53c5759a8248649a8072788b5e88a4af714998c8"
+checksum = "3c288d496168268d198d9b53ee9f4f9d260a55ba4df9877ea1d4486ad6109e0f"
 dependencies = [
  "anchor-syn",
- "bs58",
+ "bs58 0.5.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -86,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-constant"
-version = "0.31.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a98126ebfc96d6248899caadc9ea7c2403420c4f5c994e541802bce9f423674"
+checksum = "49b77b6948d0eeaaa129ce79eea5bbbb9937375a9241d909ca8fb9e006bb6e90"
 dependencies = [
  "anchor-syn",
  "quote",
@@ -97,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-error"
-version = "0.31.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a4dcb403f872fbcd0910fc39a3e05bb6c43a8399f915a1878e62eb680fbb23"
+checksum = "4d20bb569c5a557c86101b944721d865e1fd0a4c67c381d31a44a84f07f84828"
 dependencies = [
  "anchor-syn",
  "quote",
@@ -108,9 +120,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-event"
-version = "0.31.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420d651b2703ccff86f6c4b7c394140cb85049787c078a5f8280506121d48065"
+checksum = "4cebd8d0671a3a9dc3160c48598d652c34c77de6be4d44345b8b514323284d57"
 dependencies = [
  "anchor-syn",
  "proc-macro2",
@@ -120,14 +132,14 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-program"
-version = "0.31.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258f3a9f47db7f4199888df0ee67e42b960a7acb8f5c336b585d4eb243b9665"
+checksum = "efb2a5eb0860e661ab31aff7bb5e0288357b176380e985bade4ccb395981b42d"
 dependencies = [
  "anchor-lang-idl",
  "anchor-syn",
  "anyhow",
- "bs58",
+ "bs58 0.5.1",
  "heck",
  "proc-macro2",
  "quote",
@@ -137,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-derive-accounts"
-version = "0.31.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "097147501de51105d8dbdad9bd5a96a1b17ecbb2cee9f200d6167031372eab3b"
+checksum = "04368b5abef4266250ca8d1d12f4dff860242681e4ec22b885dcfe354fd35aa1"
 dependencies = [
  "anchor-syn",
  "quote",
@@ -148,12 +160,12 @@ dependencies = [
 
 [[package]]
 name = "anchor-derive-serde"
-version = "0.31.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5a24721da4ed67f0a1391cac27ea7e51c255cbd94cdcc6728a0aa56227628d0"
+checksum = "e0bb0e0911ad4a70cab880cdd6287fe1e880a1a9d8e4e6defa8e9044b9796a6c"
 dependencies = [
  "anchor-syn",
- "borsh-derive-internal",
+ "borsh-derive-internal 0.10.4",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -161,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-derive-space"
-version = "0.31.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f41986f84d238a2f7a807f3a98da5df0e97ebe23f29f7d67b8cdd4fd80bc1ba1"
+checksum = "5ef415ff156dc82e9ecb943189b0cb241b3a6bfc26a180234dc21bd3ef3ce0cb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -172,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-lang"
-version = "0.31.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba81a0543fee1b7b610fe9ebedbae6a14e8d3e85a6a6dd48871d48a08880195"
+checksum = "6620c9486d9d36a4389cab5e37dc34a42ed0bfaa62e6a75a2999ce98f8f2e373"
 dependencies = [
  "anchor-attribute-access-control",
  "anchor-attribute-account",
@@ -186,12 +198,14 @@ dependencies = [
  "anchor-derive-serde",
  "anchor-derive-space",
  "anchor-lang-idl",
+ "arrayref",
  "base64 0.21.7",
  "bincode",
  "borsh 0.10.4",
  "bytemuck",
+ "getrandom 0.2.15",
  "solana-program",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -221,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-spl"
-version = "0.31.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9d989ebc64e6c1a9828d3a6f7b8e7a4d63cc8a4f667dcb191bd9067a3375c20"
+checksum = "04bd077c34449319a1e4e0bc21cea572960c9ae0d0fefda0dd7c52fcc3c647a3"
 dependencies = [
  "anchor-lang",
  "spl-associated-token-account",
@@ -236,12 +250,12 @@ dependencies = [
 
 [[package]]
 name = "anchor-syn"
-version = "0.31.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "564685b759db12a2424d1b2688cfdf0fec26a023813bc461274754fb0e5d97b0"
+checksum = "f99daacb53b55cfd37ce14d6c9905929721137fd4c67bbab44a19802aecb622f"
 dependencies = [
  "anyhow",
- "bs58",
+ "bs58 0.5.1",
  "cargo_toml",
  "heck",
  "proc-macro2",
@@ -250,7 +264,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "syn 1.0.109",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -258,6 +272,123 @@ name = "anyhow"
 version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+
+[[package]]
+name = "ark-bn254"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a22f4561524cd949590d78d7d4c5df8f592430d221f7f3c9497bbafd8972120f"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
+dependencies = [
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "hashbrown 0.13.2",
+ "itertools",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "digest 0.10.7",
+ "itertools",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
+dependencies = [
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-serialize-derive",
+ "ark-std",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
 
 [[package]]
 name = "arrayref"
@@ -270,6 +401,23 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "autocfg"
@@ -290,12 +438,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +451,18 @@ name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "blake3"
@@ -330,6 +484,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
 
@@ -340,6 +495,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
+
+[[package]]
+name = "borsh"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15bf3650200d8bffa99015595e10f1fbd17de07abbc25bb067da79e769939bfa"
+dependencies = [
+ "borsh-derive 0.9.3",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -364,12 +535,25 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6441c552f230375d18e3cc377677914d2ca2b0d36e52129fe15450a2dce46775"
+dependencies = [
+ "borsh-derive-internal 0.9.3",
+ "borsh-schema-derive-internal 0.9.3",
+ "proc-macro-crate 0.1.5",
+ "proc-macro2",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "borsh-derive"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831213f80d9423998dd696e2c5345aba6be7a0bd8cd19e31c5243e13df1cef89"
 dependencies = [
- "borsh-derive-internal",
- "borsh-schema-derive-internal",
+ "borsh-derive-internal 0.10.4",
+ "borsh-schema-derive-internal 0.10.4",
  "proc-macro-crate 0.1.5",
  "proc-macro2",
  "syn 1.0.109",
@@ -390,9 +574,31 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive-internal"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "borsh-derive-internal"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65d6ba50644c98714aa2a70d13d7df3cd75cd2b523a2b452bf010443800976b3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "borsh-schema-derive-internal"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -409,6 +615,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "bs58"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bs58"
@@ -477,6 +689,8 @@ version = "1.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -493,13 +707,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "cipher"
-version = "0.4.4"
+name = "chrono"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
- "crypto-common",
- "inout",
+ "num-traits",
+]
+
+[[package]]
+name = "cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -543,6 +765,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crunchy"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,46 +802,95 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
 ]
 
 [[package]]
-name = "ctr"
-version = "0.9.2"
+name = "crypto-mac"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
+name = "ctr"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.3"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
 dependencies = [
- "cfg-if",
- "cpufeatures",
- "curve25519-dalek-derive",
- "digest 0.10.7",
- "fiat-crypto",
- "rand_core 0.6.4",
- "rustc_version",
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.5.1",
  "serde",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
-name = "curve25519-dalek-derive"
-version = "0.1.1"
+name = "darling"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "default-boxed"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b48cc7cb0b3bcd8acee5eb26e45f8f4b597c5e57a67deb86e3d1d4a1e57a1c31"
+dependencies = [
+ "default-boxed-derive",
+]
+
+[[package]]
+name = "default-boxed-derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94bbd6a078996f7e3af0e053377eb5577dee801eae2f22af2cd1e58fa33a0f5e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -602,6 +898,17 @@ name = "derivation-path"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e5c37193a1db1d8ed868c03ec7b152175f26160a5b740e5e484143877e0adf0"
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "digest"
@@ -624,10 +931,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand 0.7.3",
+ "serde",
+ "sha2 0.9.9",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek-bip32"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d2be62a4061b872c8c0873ee4fc6f101ce7b889d039f019c5fa2af471a59908"
+dependencies = [
+ "derivation-path",
+ "ed25519-dalek",
+ "hmac 0.12.1",
+ "sha2 0.10.8",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "env_logger"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
 
 [[package]]
 name = "equivalent"
@@ -642,27 +997,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
 
 [[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
-
-[[package]]
-name = "five8_const"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26dec3da8bc3ef08f2c04f61eab298c3ab334523e55f076354d6d6f613799a7b"
-dependencies = [
- "five8_core",
-]
-
-[[package]]
-name = "five8_core"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2551bf44bc5f776c15044b9b94153a00198be06743e262afaaa61f11ac7523a5"
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -674,6 +1008,7 @@ version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
+ "serde",
  "typenum",
  "version_check",
 ]
@@ -685,8 +1020,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -703,12 +1040,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash 0.7.8",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
 ]
 
 [[package]]
@@ -727,12 +1085,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hmac"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac-drbg"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
+dependencies = [
+ "digest 0.9.0",
+ "generic-array",
+ "hmac 0.8.1",
+]
+
+[[package]]
+name = "humantime"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "im"
+version = "15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
+dependencies = [
+ "bitmaps",
+ "rand_core 0.6.4",
+ "rand_xoshiro",
+ "rayon",
+ "serde",
+ "sized-chunks",
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -746,28 +1162,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "invest-in-sol"
 version = "0.1.0"
 dependencies = [
+ "ahash 0.8.11",
  "anchor-lang",
  "anchor-spl",
+ "bincode",
  "constant-product-curve",
+ "default-boxed",
+ "solana-program",
+ "whirlpool-cpi",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
@@ -777,6 +1189,16 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jobserver"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+dependencies = [
+ "getrandom 0.3.2",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -818,12 +1240,14 @@ dependencies = [
  "arrayref",
  "base64 0.12.3",
  "digest 0.9.0",
+ "hmac-drbg",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
  "rand 0.7.3",
  "serde",
  "sha2 0.9.9",
+ "typenum",
 ]
 
 [[package]]
@@ -856,6 +1280,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "light-poseidon"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c9a85a9752c549ceb7578064b4ed891179d20acd85f27318573b64d2d7ee7ee"
+dependencies = [
+ "ark-bn254",
+ "ark-ff",
+ "num-bigint",
+ "thiserror",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -876,6 +1312,15 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memmap2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -994,6 +1439,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pbkdf2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216eaa586a190f0a738f2f918511eecfa90f13295abec0e457cdebcceda80cbd"
+dependencies = [
+ "crypto-mac",
+]
+
+[[package]]
 name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1010,9 +1470,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "polyval"
-version = "0.6.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1066,6 +1526,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "qualifier_attr"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e2e25ee72f5b24d773cae88422baddefff7714f97aab68d96fe2b6fc4a28fb2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1073,6 +1544,12 @@ checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
@@ -1146,6 +1623,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1182,6 +1688,12 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -1267,6 +1779,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
+dependencies = [
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1292,6 +1826,18 @@ dependencies = [
 
 [[package]]
 name = "sha3"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "keccak",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha3"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
@@ -1307,634 +1853,202 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "sized-chunks"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
+dependencies = [
+ "bitmaps",
+ "typenum",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
-name = "solana-account"
-version = "2.2.1"
+name = "solana-frozen-abi"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f949fe4edaeaea78c844023bfc1c898e0b1f5a100f8a8d2d0f85d0a7b090258"
+checksum = "03ab2c30c15311b511c0d1151e4ab6bc9a3e080a37e7c6e7c2d96f5784cf9434"
 dependencies = [
- "solana-account-info",
- "solana-clock",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk-ids",
-]
-
-[[package]]
-name = "solana-account-info"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c17d606a298a205fae325489fbed88ee6dc4463c111672172327e741c8905d"
-dependencies = [
- "bincode",
- "serde",
- "solana-program-error",
- "solana-program-memory",
- "solana-pubkey",
-]
-
-[[package]]
-name = "solana-address-lookup-table-interface"
-version = "2.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1673f67efe870b64a65cb39e6194be5b26527691ce5922909939961a6e6b395"
-dependencies = [
- "bincode",
- "bytemuck",
- "serde",
- "serde_derive",
- "solana-clock",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk-ids",
- "solana-slot-hashes",
-]
-
-[[package]]
-name = "solana-atomic-u64"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52e52720efe60465b052b9e7445a01c17550666beec855cce66f44766697bc2"
-dependencies = [
- "parking_lot",
-]
-
-[[package]]
-name = "solana-big-mod-exp"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75db7f2bbac3e62cfd139065d15bcda9e2428883ba61fc8d27ccb251081e7567"
-dependencies = [
- "num-bigint",
- "num-traits",
- "solana-define-syscall",
-]
-
-[[package]]
-name = "solana-bincode"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a3787b8cf9c9fe3dd360800e8b70982b9e5a8af9e11c354b6665dd4a003adc"
-dependencies = [
- "bincode",
- "serde",
- "solana-instruction",
-]
-
-[[package]]
-name = "solana-blake3-hasher"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a0801e25a1b31a14494fc80882a036be0ffd290efc4c2d640bfcca120a4672"
-dependencies = [
- "blake3",
- "solana-define-syscall",
- "solana-hash",
- "solana-sanitize",
-]
-
-[[package]]
-name = "solana-borsh"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718333bcd0a1a7aed6655aa66bef8d7fb047944922b2d3a18f49cbc13e73d004"
-dependencies = [
- "borsh 0.10.4",
- "borsh 1.5.7",
-]
-
-[[package]]
-name = "solana-clock"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c2177a1b9fe8326004f1151a5acd124420b737811080b1035df31349e4d892"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-cpi"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc71126edddc2ba014622fc32d0f5e2e78ec6c5a1e0eb511b85618c09e9ea11"
-dependencies = [
- "solana-account-info",
- "solana-define-syscall",
- "solana-instruction",
- "solana-program-error",
- "solana-pubkey",
- "solana-stable-layout",
-]
-
-[[package]]
-name = "solana-curve25519"
-version = "2.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cf33066cc9a741ff4cc4d171a4a816ea06f9826516b7360d997179a1b3244f"
-dependencies = [
- "bytemuck",
- "bytemuck_derive",
- "curve25519-dalek",
- "solana-define-syscall",
- "subtle",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "solana-decode-error"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a6a6383af236708048f8bd8d03db8ca4ff7baf4a48e5d580f4cce545925470"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "solana-define-syscall"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf784bb2cb3e02cac9801813c30187344228d2ae952534902108f6150573a33d"
-
-[[package]]
-name = "solana-derivation-path"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "939756d798b25c5ec3cca10e06212bdca3b1443cb9bb740a38124f58b258737b"
-dependencies = [
- "derivation-path",
- "qstring",
- "uriparse",
-]
-
-[[package]]
-name = "solana-epoch-rewards"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b575d3dd323b9ea10bb6fe89bf6bf93e249b215ba8ed7f68f1a3633f384db7"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-hash",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-epoch-schedule"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fce071fbddecc55d727b1d7ed16a629afe4f6e4c217bc8d00af3b785f6f67ed"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-example-mocks"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84461d56cbb8bb8d539347151e0525b53910102e4bced875d49d5139708e39d3"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-address-lookup-table-interface",
- "solana-clock",
- "solana-hash",
- "solana-instruction",
- "solana-keccak-hasher",
- "solana-message",
- "solana-nonce",
- "solana-pubkey",
- "solana-sdk-ids",
- "solana-system-interface",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "solana-feature-gate-interface"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9c7fbf3e58b64a667c5f35e90af580538a95daea7001ff7806c0662d301bdf"
-dependencies = [
- "bincode",
- "serde",
- "serde_derive",
- "solana-account",
- "solana-account-info",
- "solana-instruction",
- "solana-program-error",
- "solana-pubkey",
- "solana-rent",
- "solana-sdk-ids",
- "solana-system-interface",
-]
-
-[[package]]
-name = "solana-fee-calculator"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89bc408da0fb3812bc3008189d148b4d3e08252c79ad810b245482a3f70cd8d"
-dependencies = [
- "log",
- "serde",
- "serde_derive",
-]
-
-[[package]]
-name = "solana-hash"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf7bcb14392900fe02e4e34e90234fbf0c673d4e327888410ba99fa2ba0f4e99"
-dependencies = [
- "borsh 1.5.7",
- "bs58",
- "bytemuck",
- "bytemuck_derive",
- "js-sys",
- "serde",
- "serde_derive",
- "solana-atomic-u64",
- "solana-sanitize",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "solana-instruction"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce496a475e5062ba5de97215ab39d9c358f9c9df4bb7f3a45a1f1a8bd9065ed"
-dependencies = [
- "bincode",
- "borsh 1.5.7",
- "getrandom 0.2.15",
- "js-sys",
- "num-traits",
- "serde",
- "serde_derive",
- "solana-define-syscall",
- "solana-pubkey",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "solana-instructions-sysvar"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427f2d0d6dc0bb49f16cef5e7f975180d2e80aab9bdd3b2af68e2d029ec63f43"
-dependencies = [
- "bitflags",
- "solana-account-info",
- "solana-instruction",
- "solana-program-error",
- "solana-pubkey",
- "solana-sanitize",
- "solana-sdk-ids",
- "solana-serialize-utils",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-keccak-hasher"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7aeb957fbd42a451b99235df4942d96db7ef678e8d5061ef34c9b34cae12f79"
-dependencies = [
- "sha3",
- "solana-define-syscall",
- "solana-hash",
- "solana-sanitize",
-]
-
-[[package]]
-name = "solana-last-restart-slot"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a6360ac2fdc72e7463565cd256eedcf10d7ef0c28a1249d261ec168c1b55cdd"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-loader-v2-interface"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8ab08006dad78ae7cd30df8eea0539e207d08d91eaefb3e1d49a446e1c49654"
-dependencies = [
- "serde",
- "serde_bytes",
- "serde_derive",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk-ids",
-]
-
-[[package]]
-name = "solana-loader-v3-interface"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4be76cfa9afd84ca2f35ebc09f0da0f0092935ccdac0595d98447f259538c2"
-dependencies = [
- "serde",
- "serde_bytes",
- "serde_derive",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk-ids",
- "solana-system-interface",
-]
-
-[[package]]
-name = "solana-loader-v4-interface"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "706a777242f1f39a83e2a96a2a6cb034cb41169c6ecbee2cf09cb873d9659e7e"
-dependencies = [
- "serde",
- "serde_bytes",
- "serde_derive",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk-ids",
- "solana-system-interface",
-]
-
-[[package]]
-name = "solana-message"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6bf99c4570173710107a1f233f3bee226feea5fc817308707d4f7cb100a72d"
-dependencies = [
- "bincode",
- "blake3",
+ "block-buffer 0.10.4",
+ "bs58 0.4.0",
+ "bv",
+ "either",
+ "generic-array",
+ "im",
  "lazy_static",
+ "log",
+ "memmap2",
+ "rustc_version",
  "serde",
+ "serde_bytes",
  "serde_derive",
- "solana-bincode",
- "solana-hash",
- "solana-instruction",
- "solana-pubkey",
- "solana-sanitize",
- "solana-sdk-ids",
- "solana-short-vec",
- "solana-system-interface",
- "solana-transaction-error",
- "wasm-bindgen",
+ "sha2 0.10.8",
+ "solana-frozen-abi-macro",
+ "subtle",
+ "thiserror",
 ]
 
 [[package]]
-name = "solana-msg"
-version = "2.2.1"
+name = "solana-frozen-abi-macro"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36a1a14399afaabc2781a1db09cb14ee4cc4ee5c7a5a3cfcc601811379a8092"
+checksum = "c142f779c3633ac83c84d04ff06c70e1f558c876f13358bed77ba629c7417932"
 dependencies = [
- "solana-define-syscall",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.100",
 ]
 
 [[package]]
-name = "solana-native-token"
-version = "2.2.1"
+name = "solana-logger"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e9de00960197412e4be3902a6cd35e60817c511137aca6c34c66cd5d4017ec"
-
-[[package]]
-name = "solana-nonce"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703e22eb185537e06204a5bd9d509b948f0066f2d1d814a6f475dafb3ddf1325"
+checksum = "121d36ffb3c6b958763312cbc697fbccba46ee837d3a0aa4fc0e90fcb3b884f3"
 dependencies = [
- "serde",
- "serde_derive",
- "solana-fee-calculator",
- "solana-hash",
- "solana-pubkey",
- "solana-sha256-hasher",
+ "env_logger",
+ "lazy_static",
+ "log",
 ]
 
 [[package]]
 name = "solana-program"
-version = "2.2.1"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "586469467e93ceb79048f8d8e3a619bf61d05396ee7de95cb40280301a589d05"
+checksum = "c10f4588cefd716b24a1a40dd32c278e43a560ab8ce4de6b5805c9d113afdfa1"
 dependencies = [
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "base64 0.21.7",
  "bincode",
+ "bitflags",
  "blake3",
  "borsh 0.10.4",
+ "borsh 0.9.3",
  "borsh 1.5.7",
- "bs58",
+ "bs58 0.4.0",
+ "bv",
  "bytemuck",
+ "cc",
  "console_error_panic_hook",
  "console_log",
+ "curve25519-dalek",
  "getrandom 0.2.15",
+ "itertools",
+ "js-sys",
  "lazy_static",
+ "libc",
+ "libsecp256k1",
+ "light-poseidon",
  "log",
  "memoffset",
  "num-bigint",
  "num-derive",
  "num-traits",
+ "parking_lot",
  "rand 0.8.5",
+ "rustc_version",
+ "rustversion",
  "serde",
  "serde_bytes",
  "serde_derive",
- "solana-account-info",
- "solana-address-lookup-table-interface",
- "solana-atomic-u64",
- "solana-big-mod-exp",
- "solana-bincode",
- "solana-blake3-hasher",
- "solana-borsh",
- "solana-clock",
- "solana-cpi",
- "solana-decode-error",
- "solana-define-syscall",
- "solana-epoch-rewards",
- "solana-epoch-schedule",
- "solana-example-mocks",
- "solana-feature-gate-interface",
- "solana-fee-calculator",
- "solana-hash",
- "solana-instruction",
- "solana-instructions-sysvar",
- "solana-keccak-hasher",
- "solana-last-restart-slot",
- "solana-loader-v2-interface",
- "solana-loader-v3-interface",
- "solana-loader-v4-interface",
- "solana-message",
- "solana-msg",
- "solana-native-token",
- "solana-nonce",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-program-memory",
- "solana-program-option",
- "solana-program-pack",
- "solana-pubkey",
- "solana-rent",
- "solana-sanitize",
- "solana-sdk-ids",
+ "serde_json",
+ "sha2 0.10.8",
+ "sha3 0.10.8",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
  "solana-sdk-macro",
- "solana-secp256k1-recover",
- "solana-serde-varint",
- "solana-serialize-utils",
- "solana-sha256-hasher",
- "solana-short-vec",
- "solana-slot-hashes",
- "solana-slot-history",
- "solana-stable-layout",
- "solana-stake-interface",
- "solana-system-interface",
- "solana-sysvar",
- "solana-sysvar-id",
- "solana-vote-interface",
- "thiserror 2.0.12",
+ "thiserror",
+ "tiny-bip39",
  "wasm-bindgen",
+ "zeroize",
 ]
 
 [[package]]
-name = "solana-program-entrypoint"
-version = "2.2.1"
+name = "solana-sdk"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473ffe73c68d93e9f2aa726ad2985fe52760052709aaab188100a42c618060ec"
+checksum = "580ad66c2f7a4c3cb3244fe21440546bd500f5ecb955ad9826e92a78dded8009"
 dependencies = [
- "solana-account-info",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey",
-]
-
-[[package]]
-name = "solana-program-error"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8ae2c1a8d0d4ae865882d5770a7ebca92bab9c685e43f0461682c6c05a35bfa"
-dependencies = [
+ "assert_matches",
+ "base64 0.21.7",
+ "bincode",
+ "bitflags",
  "borsh 1.5.7",
- "num-traits",
- "serde",
- "serde_derive",
- "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-pubkey",
-]
-
-[[package]]
-name = "solana-program-memory"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b0268f6c89825fb634a34bd0c3b8fdaeaecfc3728be1d622a8ee6dd577b60d4"
-dependencies = [
- "num-traits",
- "solana-define-syscall",
-]
-
-[[package]]
-name = "solana-program-option"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc677a2e9bc616eda6dbdab834d463372b92848b2bfe4a1ed4e4b4adba3397d0"
-
-[[package]]
-name = "solana-program-pack"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "319f0ef15e6e12dc37c597faccb7d62525a509fec5f6975ecb9419efddeb277b"
-dependencies = [
- "solana-program-error",
-]
-
-[[package]]
-name = "solana-pubkey"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40db1ff5a0f8aea2c158d78ab5f2cf897848964251d1df42fef78efd3c85b863"
-dependencies = [
- "borsh 0.10.4",
- "borsh 1.5.7",
- "bs58",
+ "bs58 0.4.0",
  "bytemuck",
- "bytemuck_derive",
- "curve25519-dalek",
- "five8_const",
- "getrandom 0.2.15",
+ "byteorder",
+ "chrono",
+ "derivation-path",
+ "digest 0.10.7",
+ "ed25519-dalek",
+ "ed25519-dalek-bip32",
+ "generic-array",
+ "hmac 0.12.1",
+ "itertools",
  "js-sys",
+ "lazy_static",
+ "libsecp256k1",
+ "log",
+ "memmap2",
+ "num-derive",
  "num-traits",
+ "num_enum",
+ "pbkdf2 0.11.0",
+ "qstring",
+ "qualifier_attr",
+ "rand 0.7.3",
+ "rand 0.8.5",
+ "rustc_version",
+ "rustversion",
  "serde",
+ "serde_bytes",
  "serde_derive",
- "solana-atomic-u64",
- "solana-decode-error",
- "solana-define-syscall",
- "solana-sanitize",
- "solana-sha256-hasher",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "solana-rent"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1aea8fdea9de98ca6e8c2da5827707fb3842833521b528a713810ca685d2480"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-sdk-ids",
+ "serde_json",
+ "serde_with",
+ "sha2 0.10.8",
+ "sha3 0.10.8",
+ "siphasher",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+ "solana-logger",
+ "solana-program",
  "solana-sdk-macro",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-sanitize"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f1bc1357b8188d9c4a3af3fc55276e56987265eb7ad073ae6f8180ee54cecf"
-
-[[package]]
-name = "solana-sdk-ids"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5d8b9cc68d5c88b062a33e23a6466722467dde0035152d8fb1afbcdf350a5f"
-dependencies = [
- "solana-pubkey",
+ "thiserror",
+ "uriparse",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "solana-sdk-macro"
-version = "2.2.1"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86280da8b99d03560f6ab5aca9de2e38805681df34e0bb8f238e69b29433b9df"
+checksum = "1b75d0f193a27719257af19144fdaebec0415d1c9e9226ae4bd29b791be5e9bd"
 dependencies = [
- "bs58",
+ "bs58 0.4.0",
  "proc-macro2",
  "quote",
+ "rustversion",
  "syn 2.0.100",
-]
-
-[[package]]
-name = "solana-secp256k1-recover"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baa3120b6cdaa270f39444f5093a90a7b03d296d362878f7a6991d6de3bbe496"
-dependencies = [
- "libsecp256k1",
- "solana-define-syscall",
- "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -1944,312 +2058,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
 
 [[package]]
-name = "solana-seed-derivable"
-version = "2.2.1"
+name = "solana-zk-token-sdk"
+version = "1.18.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beb82b5adb266c6ea90e5cf3967235644848eac476c5a1f2f9283a143b7c97f"
-dependencies = [
- "solana-derivation-path",
-]
-
-[[package]]
-name = "solana-seed-phrase"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36187af2324f079f65a675ec22b31c24919cb4ac22c79472e85d819db9bbbc15"
-dependencies = [
- "hmac",
- "pbkdf2",
- "sha2 0.10.8",
-]
-
-[[package]]
-name = "solana-serde-varint"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc07d00200d82e6def2f7f7a45738e3406b17fe54a18adcf0defa16a97ccadb"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "solana-serialize-utils"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "817a284b63197d2b27afdba829c5ab34231da4a9b4e763466a003c40ca4f535e"
-dependencies = [
- "solana-instruction",
- "solana-pubkey",
- "solana-sanitize",
-]
-
-[[package]]
-name = "solana-sha256-hasher"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0037386961c0d633421f53560ad7c80675c0447cba4d1bb66d60974dd486c7ea"
-dependencies = [
- "sha2 0.10.8",
- "solana-define-syscall",
- "solana-hash",
-]
-
-[[package]]
-name = "solana-short-vec"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c54c66f19b9766a56fa0057d060de8378676cb64987533fa088861858fc5a69"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "solana-signature"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d251c8f3dc015f320b4161daac7f108156c837428e5a8cc61136d25beb11d6"
-dependencies = [
- "bs58",
- "solana-sanitize",
-]
-
-[[package]]
-name = "solana-signer"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c41991508a4b02f021c1342ba00bcfa098630b213726ceadc7cb032e051975b"
-dependencies = [
- "solana-pubkey",
- "solana-signature",
- "solana-transaction-error",
-]
-
-[[package]]
-name = "solana-slot-hashes"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8691982114513763e88d04094c9caa0376b867a29577939011331134c301ce"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-hash",
- "solana-sdk-ids",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-slot-history"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ccc1b2067ca22754d5283afb2b0126d61eae734fc616d23871b0943b0d935e"
-dependencies = [
- "bv",
- "serde",
- "serde_derive",
- "solana-sdk-ids",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-stable-layout"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f14f7d02af8f2bc1b5efeeae71bc1c2b7f0f65cd75bcc7d8180f2c762a57f54"
-dependencies = [
- "solana-instruction",
- "solana-pubkey",
-]
-
-[[package]]
-name = "solana-stake-interface"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5269e89fde216b4d7e1d1739cf5303f8398a1ff372a81232abbee80e554a838c"
-dependencies = [
- "borsh 0.10.4",
- "borsh 1.5.7",
- "num-traits",
- "serde",
- "serde_derive",
- "solana-clock",
- "solana-cpi",
- "solana-decode-error",
- "solana-instruction",
- "solana-program-error",
- "solana-pubkey",
- "solana-system-interface",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-system-interface"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7c18cb1a91c6be5f5a8ac9276a1d7c737e39a21beba9ea710ab4b9c63bc90"
-dependencies = [
- "js-sys",
- "num-traits",
- "serde",
- "serde_derive",
- "solana-decode-error",
- "solana-instruction",
- "solana-pubkey",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "solana-sysvar"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf6b44740d7f0c9f375d045c165bc0aab4a90658f92d6835aeb0649afaeaff9a"
-dependencies = [
- "base64 0.22.1",
- "bincode",
- "bytemuck",
- "bytemuck_derive",
- "lazy_static",
- "serde",
- "serde_derive",
- "solana-account-info",
- "solana-clock",
- "solana-define-syscall",
- "solana-epoch-rewards",
- "solana-epoch-schedule",
- "solana-fee-calculator",
- "solana-hash",
- "solana-instruction",
- "solana-instructions-sysvar",
- "solana-last-restart-slot",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-program-memory",
- "solana-pubkey",
- "solana-rent",
- "solana-sanitize",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-slot-hashes",
- "solana-slot-history",
- "solana-stake-interface",
- "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-sysvar-id"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5762b273d3325b047cfda250787f8d796d781746860d5d0a746ee29f3e8812c1"
-dependencies = [
- "solana-pubkey",
- "solana-sdk-ids",
-]
-
-[[package]]
-name = "solana-transaction-error"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a9dc8fdb61c6088baab34fc3a8b8473a03a7a5fd404ed8dd502fa79b67cb1"
-dependencies = [
- "solana-instruction",
- "solana-sanitize",
-]
-
-[[package]]
-name = "solana-vote-interface"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b630547b7f12ee742e1c5069951fedba0fe5cbd4786f6342a779384e2b11f71"
-dependencies = [
- "bincode",
- "num-derive",
- "num-traits",
- "serde",
- "serde_derive",
- "solana-clock",
- "solana-decode-error",
- "solana-hash",
- "solana-instruction",
- "solana-pubkey",
- "solana-rent",
- "solana-sdk-ids",
- "solana-serde-varint",
- "solana-serialize-utils",
- "solana-short-vec",
- "solana-system-interface",
-]
-
-[[package]]
-name = "solana-zk-sdk"
-version = "2.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a153bff0be31a58dacd7f40bc37fc80f5bb7cb3f38fb62e7a2777a8b48de25"
+checksum = "7cbdf4249b6dfcbba7d84e2b53313698043f60f8e22ce48286e6fbe8a17c8d16"
 dependencies = [
  "aes-gcm-siv",
- "base64 0.22.1",
+ "base64 0.21.7",
  "bincode",
  "bytemuck",
- "bytemuck_derive",
+ "byteorder",
  "curve25519-dalek",
+ "getrandom 0.1.16",
  "itertools",
- "js-sys",
  "lazy_static",
  "merlin",
  "num-derive",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.7.3",
  "serde",
- "serde_derive",
  "serde_json",
- "sha3",
- "solana-derivation-path",
- "solana-instruction",
- "solana-pubkey",
- "solana-sdk-ids",
- "solana-seed-derivable",
- "solana-seed-phrase",
- "solana-signature",
- "solana-signer",
+ "sha3 0.9.1",
+ "solana-program",
+ "solana-sdk",
  "subtle",
- "thiserror 2.0.12",
- "wasm-bindgen",
+ "thiserror",
  "zeroize",
 ]
 
 [[package]]
 name = "spl-associated-token-account"
-version = "6.0.0"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76fee7d65013667032d499adc3c895e286197a35a0d3a4643c80e7fd3e9969e3"
+checksum = "143109d789171379e6143ef23191786dfaac54289ad6e7917cfb26b36c432b10"
 dependencies = [
+ "assert_matches",
  "borsh 1.5.7",
  "num-derive",
  "num-traits",
  "solana-program",
- "spl-associated-token-account-client",
  "spl-token",
  "spl-token-2022",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "spl-associated-token-account-client"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f8349dbcbe575f354f9a533a21f272f3eb3808a49e2fdc1c34393b88ba76cb"
-dependencies = [
- "solana-instruction",
- "solana-pubkey",
+ "thiserror",
 ]
 
 [[package]]
 name = "spl-discriminator"
-version = "0.4.1"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7398da23554a31660f17718164e31d31900956054f54f52d5ec1be51cb4f4b3"
+checksum = "210101376962bb22bb13be6daea34656ea1cbc248fce2164b146e39203b55e03"
 dependencies = [
  "bytemuck",
- "solana-program-error",
- "solana-sha256-hasher",
+ "solana-program",
  "spl-discriminator-derive",
 ]
 
@@ -2274,67 +2134,42 @@ dependencies = [
  "quote",
  "sha2 0.10.8",
  "syn 2.0.100",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "spl-elgamal-registry"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce0f668975d2b0536e8a8fd60e56a05c467f06021dae037f1d0cfed0de2e231d"
-dependencies = [
- "bytemuck",
- "solana-program",
- "solana-zk-sdk",
- "spl-pod",
- "spl-token-confidential-transfer-proof-extraction",
+ "thiserror",
 ]
 
 [[package]]
 name = "spl-memo"
-version = "6.0.0"
+version = "4.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f09647c0974e33366efeb83b8e2daebb329f0420149e74d3a4bd2c08cf9f7cb"
+checksum = "a49f49f95f2d02111ded31696ab38a081fab623d4c76bd4cb074286db4560836"
 dependencies = [
- "solana-account-info",
- "solana-instruction",
- "solana-msg",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-pubkey",
+ "solana-program",
 ]
 
 [[package]]
 name = "spl-pod"
-version = "0.5.1"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d994afaf86b779104b4a95ba9ca75b8ced3fdb17ee934e38cb69e72afbe17799"
+checksum = "c52d84c55efeef8edcc226743dc089d7e3888b8e3474569aa3eff152b37b9996"
 dependencies = [
  "borsh 1.5.7",
  "bytemuck",
- "bytemuck_derive",
- "num-derive",
- "num-traits",
- "solana-decode-error",
- "solana-msg",
- "solana-program-error",
- "solana-program-option",
- "solana-pubkey",
- "solana-zk-sdk",
- "thiserror 2.0.12",
+ "solana-program",
+ "solana-zk-token-sdk",
+ "spl-program-error",
 ]
 
 [[package]]
 name = "spl-program-error"
-version = "0.6.0"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d39b5186f42b2b50168029d81e58e800b690877ef0b30580d107659250da1d1"
+checksum = "e45a49acb925db68aa501b926096b2164adbdcade7a0c24152af9f0742d0a602"
 dependencies = [
  "num-derive",
  "num-traits",
  "solana-program",
  "spl-program-error-derive",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -2351,31 +2186,23 @@ dependencies = [
 
 [[package]]
 name = "spl-tlv-account-resolution"
-version = "0.9.0"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd99ff1e9ed2ab86e3fd582850d47a739fec1be9f4661cba1782d3a0f26805f3"
+checksum = "fab8edfd37be5fa17c9e42c1bff86abbbaf0494b031b37957f2728ad2ff842ba"
 dependencies = [
  "bytemuck",
- "num-derive",
- "num-traits",
- "solana-account-info",
- "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey",
+ "solana-program",
  "spl-discriminator",
  "spl-pod",
  "spl-program-error",
  "spl-type-length-value",
- "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "spl-token"
-version = "7.0.0"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed320a6c934128d4f7e54fe00e16b8aeaecf215799d060ae14f93378da6dc834"
+checksum = "b9eb465e4bf5ce1d498f05204c8089378c1ba34ef2777ea95852fc53a1fd4fb2"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -2383,14 +2210,14 @@ dependencies = [
  "num-traits",
  "num_enum",
  "solana-program",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
 name = "spl-token-2022"
-version = "6.0.0"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b27f7405010ef816587c944536b0eafbcc35206ab6ba0f2ca79f1d28e488f4f"
+checksum = "4c39e416aeb1ea0b22f3b2bbecaf7e38a92a1aa8f4a0c5785c94179694e846a0"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -2399,146 +2226,84 @@ dependencies = [
  "num_enum",
  "solana-program",
  "solana-security-txt",
- "solana-zk-sdk",
- "spl-elgamal-registry",
+ "solana-zk-token-sdk",
  "spl-memo",
  "spl-pod",
  "spl-token",
- "spl-token-confidential-transfer-ciphertext-arithmetic",
- "spl-token-confidential-transfer-proof-extraction",
- "spl-token-confidential-transfer-proof-generation",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
  "spl-transfer-hook-interface",
  "spl-type-length-value",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "spl-token-confidential-transfer-ciphertext-arithmetic"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170378693c5516090f6d37ae9bad2b9b6125069be68d9acd4865bbe9fc8499fd"
-dependencies = [
- "base64 0.22.1",
- "bytemuck",
- "solana-curve25519",
- "solana-zk-sdk",
-]
-
-[[package]]
-name = "spl-token-confidential-transfer-proof-extraction"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff2d6a445a147c9d6dd77b8301b1e116c8299601794b558eafa409b342faf96"
-dependencies = [
- "bytemuck",
- "solana-curve25519",
- "solana-program",
- "solana-zk-sdk",
- "spl-pod",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-token-confidential-transfer-proof-generation"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8627184782eec1894de8ea26129c61303f1f0adeed65c20e0b10bc584f09356d"
-dependencies = [
- "curve25519-dalek",
- "solana-zk-sdk",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
 name = "spl-token-group-interface"
-version = "0.5.0"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d595667ed72dbfed8c251708f406d7c2814a3fa6879893b323d56a10bedfc799"
+checksum = "014817d6324b1e20c4bbc883e8ee30a5faa13e59d91d1b2b95df98b920150c17"
 dependencies = [
  "bytemuck",
- "num-derive",
- "num-traits",
- "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey",
+ "solana-program",
  "spl-discriminator",
  "spl-pod",
- "thiserror 1.0.69",
+ "spl-program-error",
 ]
 
 [[package]]
 name = "spl-token-metadata-interface"
-version = "0.6.0"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb9c89dbc877abd735f05547dcf9e6e12c00c11d6d74d8817506cab4c99fdbb"
+checksum = "f3da00495b602ebcf5d8ba8b3ecff1ee454ce4c125c9077747be49c2d62335ba"
 dependencies = [
  "borsh 1.5.7",
- "num-derive",
- "num-traits",
- "solana-borsh",
- "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey",
+ "solana-program",
  "spl-discriminator",
  "spl-pod",
+ "spl-program-error",
  "spl-type-length-value",
- "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "spl-transfer-hook-interface"
-version = "0.9.0"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa7503d52107c33c88e845e1351565050362c2314036ddf19a36cd25137c043"
+checksum = "a9b5c08a89838e5a2931f79b17f611857f281a14a2100968a3ccef352cb7414b"
 dependencies = [
  "arrayref",
  "bytemuck",
- "num-derive",
- "num-traits",
- "solana-account-info",
- "solana-cpi",
- "solana-decode-error",
- "solana-instruction",
- "solana-msg",
- "solana-program-error",
- "solana-pubkey",
+ "solana-program",
  "spl-discriminator",
  "spl-pod",
  "spl-program-error",
  "spl-tlv-account-resolution",
  "spl-type-length-value",
- "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "spl-type-length-value"
-version = "0.7.0"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba70ef09b13af616a4c987797870122863cba03acc4284f226a4473b043923f9"
+checksum = "c872f93d0600e743116501eba2d53460e73a12c9a496875a42a7d70e034fe06d"
 dependencies = [
  "bytemuck",
- "num-derive",
- "num-traits",
- "solana-account-info",
- "solana-decode-error",
- "solana-msg",
- "solana-program-error",
+ "solana-program",
  "spl-discriminator",
  "spl-pod",
- "thiserror 1.0.69",
+ "spl-program-error",
 ]
 
 [[package]]
-name = "subtle"
-version = "2.6.1"
+name = "strsim"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
@@ -2563,21 +2328,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
-dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -2592,14 +2357,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror-impl"
-version = "2.0.12"
+name = "tiny-bip39"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "ffc59cb9dfc85bb312c3a78fd6aa8a8582e310b0fa885d5bb877f6dcc601839d"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
+ "anyhow",
+ "hmac 0.8.1",
+ "once_cell",
+ "pbkdf2 0.4.0",
+ "rand 0.7.3",
+ "rustc-hash",
+ "sha2 0.9.9",
+ "thiserror",
+ "unicode-normalization",
+ "wasm-bindgen",
+ "zeroize",
 ]
 
 [[package]]
@@ -2673,6 +2446,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2680,11 +2462,11 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "universal-hash"
-version = "0.5.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
- "crypto-common",
+ "generic-array",
  "subtle",
 ]
 
@@ -2715,6 +2497,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2782,6 +2573,56 @@ checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "whirlpool-cpi"
+version = "0.1.4"
+source = "git+https://github.com/orca-so/whirlpool-cpi?branch=anchor%2F0.30.1#0449cf85a0e93686710b5dbfefb69704a98ef82a"
+dependencies = [
+ "anchor-lang",
+ "bincode",
+ "default-boxed",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]
@@ -2858,6 +2699,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2899,9 +2749,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,7 @@ codegen-units = 1
 opt-level = 3
 incremental = false
 codegen-units = 1
+
+# unpack TickArray
+bincode = "1"
+default-boxed = "0.2.0"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "lint": "prettier */*.js \"*/**/*{.js,.ts}\" --check"
   },
   "dependencies": {
-    "@coral-xyz/anchor": "^0.31.0"
+    "@coral-xyz/anchor": "^0.30.1"
   },
   "devDependencies": {
     "chai": "^4.3.4",

--- a/programs/invest-in-sol/Cargo.toml
+++ b/programs/invest-in-sol/Cargo.toml
@@ -18,6 +18,16 @@ idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 
 
 [dependencies]
-anchor-lang = { version = "0.31.0", features = ["init-if-needed"] }
-anchor-spl = "0.31.0"
+# orca cpi requires 0.30.1 for the time being
+anchor-lang = { version = "0.30.1", features = ["init-if-needed"] }
+anchor-spl = "0.30.1"
 constant-product-curve = { git = "https://github.com/deanmlittle/constant-product-curve.git" }
+
+# orca requirements
+whirlpool-cpi = { git = "https://github.com/orca-so/whirlpool-cpi", branch = "anchor/0.30.1" }
+solana-program = ">=1.18, <2"
+# https://github.com/solana-labs/solana/issues/34609
+ahash = "=0.8.11"
+# unpack orca TickArray
+bincode = "1"
+default-boxed = "0.2.0"

--- a/programs/invest-in-sol/src/instructions/cpi/loopscale/cpi/collateral.rs
+++ b/programs/invest-in-sol/src/instructions/cpi/loopscale/cpi/collateral.rs
@@ -1,0 +1,129 @@
+use anchor_lang::prelude::*;
+use crate::instructions::loopscale::types::{
+    accounts::*, instructions::*, pod::*,
+};
+
+#[derive(Accounts)]
+pub struct DepositCollateral<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub borrower: Signer<'info>,
+    #[account(mut)]
+    pub loan: AccountInfo<'info>,
+    #[account(mut)]
+    pub borrower_collateral_ta: AccountInfo<'info>,
+    #[account(mut)]
+    pub loan_collateral_ta: AccountInfo<'info>,
+    pub deposit_mint: AccountInfo<'info>,
+    pub system_program: AccountInfo<'info>,
+    pub token_program: AccountInfo<'info>,
+    pub associated_token_program: AccountInfo<'info>,
+    pub event_authority: AccountInfo<'info>,
+    pub program: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct WithdrawCollateral<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    #[account(mut)]
+    pub borrower: Signer<'info>,
+    #[account(mut)]
+    pub loan: AccountInfo<'info>,
+    #[account(mut)]
+    pub borrower_ta: AccountInfo<'info>,
+    #[account(mut)]
+    pub loan_ta: AccountInfo<'info>,
+    pub system_program: AccountInfo<'info>,
+    pub asset_mint: AccountInfo<'info>,
+    pub token_program: AccountInfo<'info>,
+    pub associated_token_program: AccountInfo<'info>,
+    pub event_authority: AccountInfo<'info>,
+    pub program: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct ManageCollateralClaimOrcaFee<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub borrower: Signer<'info>,
+    pub loan: AccountInfo<'info>,
+    #[account(mut)]
+    pub whirlpool: AccountInfo<'info>,
+    #[account(mut)]
+    pub token_vault_a: AccountInfo<'info>,
+    #[account(mut)]
+    pub token_vault_b: AccountInfo<'info>,
+    #[account(mut)]
+    pub tick_array_lower: AccountInfo<'info>,
+    #[account(mut)]
+    pub tick_array_upper: AccountInfo<'info>,
+    #[account(mut)]
+    pub position: AccountInfo<'info>,
+    #[account(mut)]
+    pub position_token_account: AccountInfo<'info>,
+    #[account(mut)]
+    pub borrower_ta_a: AccountInfo<'info>,
+    #[account(mut)]
+    pub borrower_ta_b: AccountInfo<'info>,
+    #[account(mut)]
+    pub loan_ta_a: AccountInfo<'info>,
+    #[account(mut)]
+    pub loan_ta_b: AccountInfo<'info>,
+    pub mint_a: AccountInfo<'info>,
+    pub mint_b: AccountInfo<'info>,
+    pub whirlpool_program: AccountInfo<'info>,
+    pub token_program: AccountInfo<'info>,
+    pub token_2022_program: AccountInfo<'info>,
+    pub associated_token_program: AccountInfo<'info>,
+    pub system_program: AccountInfo<'info>,
+    pub memo_program: AccountInfo<'info>,
+}
+
+pub fn deposit_collateral<'a>(
+    ctx: CpiContext<'_, '_, '_, 'a, DepositCollateral<'a>>,
+    params: DepositCollateralParams,
+) -> Result<()> {
+    let ix = crate::instructions::loopscale::instruction::deposit_collateral(
+        ctx.program.key(),
+        params,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &ToAccountInfos::to_account_infos(&ctx),
+        ctx.signer_seeds,
+    )?;
+    Ok(())
+}
+
+pub fn withdraw_collateral<'a>(
+    ctx: CpiContext<'_, '_, '_, 'a, WithdrawCollateral<'a>>,
+    params: WithdrawCollateralParams,
+) -> Result<()> {
+    let ix = crate::instructions::loopscale::instruction::withdraw_collateral(
+        ctx.program.key(),
+        params,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &ToAccountInfos::to_account_infos(&ctx),
+        ctx.signer_seeds,
+    )?;
+    Ok(())
+}
+
+pub fn manage_collateral_claim_orca_fee<'a>(
+    ctx: CpiContext<'_, '_, '_, 'a, ManageCollateralClaimOrcaFee<'a>>,
+    close_ta: bool,
+) -> Result<()> {
+    let ix = crate::instructions::loopscale::instruction::manage_collateral_claim_orca_fee(
+        ctx.program.key(),
+        close_ta,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &ToAccountInfos::to_account_infos(&ctx),
+        ctx.signer_seeds,
+    )?;
+    Ok(())
+} 

--- a/programs/invest-in-sol/src/instructions/cpi/loopscale/cpi/loan.rs
+++ b/programs/invest-in-sol/src/instructions/cpi/loopscale/cpi/loan.rs
@@ -1,0 +1,370 @@
+use anchor_lang::prelude::*;
+use crate::instructions::loopscale::types::{
+    accounts::*, instructions::*, pod::*,
+};
+
+#[derive(Accounts)]
+pub struct CreateLoan<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    #[account(mut)]
+    pub borrower: Signer<'info>,
+    #[account(mut)]
+    pub loan: AccountInfo<'info>,
+    #[account(mut)]
+    pub strategy: AccountInfo<'info>,
+    pub market_information: AccountInfo<'info>,
+    pub principal_mint: AccountInfo<'info>,
+    pub collateral_mint: AccountInfo<'info>,
+    #[account(mut)]
+    pub borrower_principal_ta: AccountInfo<'info>,
+    #[account(mut)]
+    pub strategy_principal_ta: AccountInfo<'info>,
+    #[account(mut)]
+    pub borrower_collateral_ta: AccountInfo<'info>,
+    #[account(mut)]
+    pub loan_collateral_ta: AccountInfo<'info>,
+    pub principal_token_program: AccountInfo<'info>,
+    pub collateral_token_program: AccountInfo<'info>,
+    pub associated_token_program: AccountInfo<'info>,
+    pub system_program: AccountInfo<'info>,
+    pub event_authority: AccountInfo<'info>,
+    pub program: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct OpenLoop<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub borrower: Signer<'info>,
+    #[account(mut)]
+    pub loan: AccountInfo<'info>,
+    #[account(mut)]
+    pub strategy: AccountInfo<'info>,
+    pub market_information: AccountInfo<'info>,
+    pub principal_mint: AccountInfo<'info>,
+    pub collateral_mint: AccountInfo<'info>,
+    #[account(mut)]
+    pub borrower_principal_ta: AccountInfo<'info>,
+    #[account(mut)]
+    pub strategy_principal_ta: AccountInfo<'info>,
+    #[account(mut)]
+    pub borrower_collateral_ta: AccountInfo<'info>,
+    #[account(mut)]
+    pub loan_collateral_ta: AccountInfo<'info>,
+    pub principal_token_program: AccountInfo<'info>,
+    pub collateral_token_program: AccountInfo<'info>,
+    pub associated_token_program: AccountInfo<'info>,
+    pub system_program: AccountInfo<'info>,
+    pub event_authority: AccountInfo<'info>,
+    pub program: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct CloseLoop<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub borrower: Signer<'info>,
+    #[account(mut)]
+    pub loan: AccountInfo<'info>,
+    #[account(mut)]
+    pub strategy: AccountInfo<'info>,
+    pub principal_mint: AccountInfo<'info>,
+    pub collateral_mint: AccountInfo<'info>,
+    #[account(mut)]
+    pub borrower_collateral_ta: AccountInfo<'info>,
+    #[account(mut)]
+    pub loan_collateral_ta: AccountInfo<'info>,
+    #[account(mut)]
+    pub borrower_principal_ta: AccountInfo<'info>,
+    #[account(mut)]
+    pub strategy_principal_ta: AccountInfo<'info>,
+    pub principal_token_program: AccountInfo<'info>,
+    pub collateral_token_program: AccountInfo<'info>,
+    pub associated_token_program: AccountInfo<'info>,
+    pub system_program: AccountInfo<'info>,
+    pub event_authority: AccountInfo<'info>,
+    pub program: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct LiquidateLedger<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    #[account(mut)]
+    pub liquidator: Signer<'info>,
+    #[account(mut)]
+    pub borrower: AccountInfo<'info>,
+    #[account(mut)]
+    pub loan: AccountInfo<'info>,
+    #[account(mut)]
+    pub strategy: AccountInfo<'info>,
+    pub market_information: AccountInfo<'info>,
+    #[account(mut)]
+    pub liquidator_ta: AccountInfo<'info>,
+    #[account(mut)]
+    pub strategy_ta: AccountInfo<'info>,
+    pub principal_mint: AccountInfo<'info>,
+    pub associated_token_program: AccountInfo<'info>,
+    pub token_program: AccountInfo<'info>,
+    pub token_2022_program: AccountInfo<'info>,
+    pub system_program: AccountInfo<'info>,
+    pub event_authority: AccountInfo<'info>,
+    pub program: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct RefinanceLedger<'info> {
+    pub bs_auth: Signer<'info>,
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    #[account(mut)]
+    pub loan: AccountInfo<'info>,
+    #[account(mut)]
+    pub old_strategy: AccountInfo<'info>,
+    #[account(mut)]
+    pub new_strategy: AccountInfo<'info>,
+    #[account(mut)]
+    pub old_strategy_ta: AccountInfo<'info>,
+    #[account(mut)]
+    pub new_strategy_ta: AccountInfo<'info>,
+    pub old_strategy_market_information: AccountInfo<'info>,
+    pub new_strategy_market_information: AccountInfo<'info>,
+    pub principal_mint: AccountInfo<'info>,
+    pub token_program: AccountInfo<'info>,
+    pub associated_token_program: AccountInfo<'info>,
+    pub system_program: AccountInfo<'info>,
+    pub event_authority: AccountInfo<'info>,
+    pub program: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct SellLedger<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub lender_auth: Signer<'info>,
+    #[account(mut)]
+    pub loan: AccountInfo<'info>,
+    #[account(mut)]
+    pub new_strategy_ta: AccountInfo<'info>,
+    #[account(mut)]
+    pub lender_auth_ta: AccountInfo<'info>,
+    #[account(mut)]
+    pub old_strategy: AccountInfo<'info>,
+    #[account(mut)]
+    pub new_strategy: AccountInfo<'info>,
+    pub old_strategy_market_information: AccountInfo<'info>,
+    pub new_strategy_market_information: AccountInfo<'info>,
+    pub principal_mint: AccountInfo<'info>,
+    pub token_program: AccountInfo<'info>,
+    pub associated_token_program: AccountInfo<'info>,
+    pub system_program: AccountInfo<'info>,
+    #[account(mut)]
+    pub vault: Option<AccountInfo<'info>>,
+    #[account(mut)]
+    pub old_strategy_ta: Option<AccountInfo<'info>>,
+    pub event_authority: AccountInfo<'info>,
+    pub program: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct BorrowPrincipal<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub borrower: Signer<'info>,
+    #[account(mut)]
+    pub loan: AccountInfo<'info>,
+    #[account(mut)]
+    pub strategy: AccountInfo<'info>,
+    pub market_information: AccountInfo<'info>,
+    pub principal_mint: AccountInfo<'info>,
+    #[account(mut)]
+    pub borrower_ta: AccountInfo<'info>,
+    #[account(mut)]
+    pub strategy_ta: AccountInfo<'info>,
+    pub associated_token_program: AccountInfo<'info>,
+    pub token_program: AccountInfo<'info>,
+    pub system_program: AccountInfo<'info>,
+    pub event_authority: AccountInfo<'info>,
+    pub program: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct RepayPrincipal<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub borrower: Signer<'info>,
+    #[account(mut)]
+    pub loan: AccountInfo<'info>,
+    #[account(mut)]
+    pub strategy: AccountInfo<'info>,
+    pub market_information: AccountInfo<'info>,
+    pub principal_mint: AccountInfo<'info>,
+    #[account(mut)]
+    pub borrower_ta: AccountInfo<'info>,
+    #[account(mut)]
+    pub strategy_ta: AccountInfo<'info>,
+    pub token_program: AccountInfo<'info>,
+    pub system_program: AccountInfo<'info>,
+    pub event_authority: AccountInfo<'info>,
+    pub program: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct UpdateLoan<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub borrower: Signer<'info>,
+    #[account(mut)]
+    pub loan: AccountInfo<'info>,
+    #[account(mut)]
+    pub strategy: AccountInfo<'info>,
+    pub market_information: AccountInfo<'info>,
+    pub system_program: AccountInfo<'info>,
+    pub event_authority: AccountInfo<'info>,
+    pub program: AccountInfo<'info>,
+}
+
+pub fn create_loan<'a>(
+    ctx: CpiContext<'_, '_, '_, 'a, CreateLoan<'a>>,
+    params: CreateLoanParams,
+) -> Result<()> {
+    let ix = crate::instructions::loopscale::instruction::create_loan(
+        ctx.program.key(),
+        params,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &ToAccountInfos::to_account_infos(&ctx),
+        ctx.signer_seeds,
+    )?;
+    Ok(())
+}
+
+pub fn open_loop<'a>(
+    ctx: CpiContext<'_, '_, '_, 'a, OpenLoop<'a>>,
+    params: OpenLoopParams,
+) -> Result<()> {
+    let ix = crate::instructions::loopscale::instruction::open_loop(
+        ctx.program.key(),
+        params,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &ToAccountInfos::to_account_infos(&ctx),
+        ctx.signer_seeds,
+    )?;
+    Ok(())
+}
+
+pub fn close_loop<'a>(
+    ctx: CpiContext<'_, '_, '_, 'a, CloseLoop<'a>>,
+    params: CloseLoopParams,
+) -> Result<()> {
+    let ix = crate::instructions::loopscale::instruction::close_loop(
+        ctx.program.key(),
+        params,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &ToAccountInfos::to_account_infos(&ctx),
+        ctx.signer_seeds,
+    )?;
+    Ok(())
+}
+
+pub fn liquidate_ledger<'a>(
+    ctx: CpiContext<'_, '_, '_, 'a, LiquidateLedger<'a>>,
+    params: LiquidateLedgerParams,
+) -> Result<()> {
+    let ix = crate::instructions::loopscale::instruction::liquidate_ledger(
+        ctx.program.key(),
+        params,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &ToAccountInfos::to_account_infos(&ctx),
+        ctx.signer_seeds,
+    )?;
+    Ok(())
+}
+
+pub fn refinance_ledger<'a>(
+    ctx: CpiContext<'_, '_, '_, 'a, RefinanceLedger<'a>>,
+    params: RefinanceLedgerParams,
+) -> Result<()> {
+    let ix = crate::instructions::loopscale::instruction::refinance_ledger(
+        ctx.program.key(),
+        params,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &ToAccountInfos::to_account_infos(&ctx),
+        ctx.signer_seeds,
+    )?;
+    Ok(())
+}
+
+pub fn sell_ledger<'a>(
+    ctx: CpiContext<'_, '_, '_, 'a, SellLedger<'a>>,
+    params: SellLedgerParams,
+) -> Result<()> {
+    let ix = crate::instructions::loopscale::instruction::sell_ledger(
+        ctx.program.key(),
+        params,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &ToAccountInfos::to_account_infos(&ctx),
+        ctx.signer_seeds,
+    )?;
+    Ok(())
+}
+
+pub fn borrow_principal<'a>(
+    ctx: CpiContext<'_, '_, '_, 'a, BorrowPrincipal<'a>>,
+    params: BorrowPrincipalParams,
+) -> Result<()> {
+    let ix = crate::instructions::loopscale::instruction::borrow_principal(
+        ctx.program.key(),
+        params,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &ToAccountInfos::to_account_infos(&ctx),
+        ctx.signer_seeds,
+    )?;
+    Ok(())
+}
+
+pub fn repay_principal<'a>(
+    ctx: CpiContext<'_, '_, '_, 'a, RepayPrincipal<'a>>,
+    params: RepayPrincipalParams,
+) -> Result<()> {
+    let ix = crate::instructions::loopscale::instruction::repay_principal(
+        ctx.program.key(),
+        params,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &ToAccountInfos::to_account_infos(&ctx),
+        ctx.signer_seeds,
+    )?;
+    Ok(())
+}
+
+pub fn update_loan<'a>(
+    ctx: CpiContext<'_, '_, '_, 'a, UpdateLoan<'a>>,
+    params: UpdateLoanParams,
+) -> Result<()> {
+    let ix = crate::instructions::loopscale::instruction::update_loan(
+        ctx.program.key(),
+        params,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &ToAccountInfos::to_account_infos(&ctx),
+        ctx.signer_seeds,
+    )?;
+    Ok(())
+} 

--- a/programs/invest-in-sol/src/instructions/cpi/loopscale/cpi/market.rs
+++ b/programs/invest-in-sol/src/instructions/cpi/loopscale/cpi/market.rs
@@ -1,0 +1,60 @@
+use anchor_lang::prelude::*;
+use crate::instructions::loopscale::types::{
+    accounts::*, instructions::*, pod::*,
+};
+
+#[derive(Accounts)]
+pub struct CreateMarketInformation<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub manager: Signer<'info>,
+    #[account(mut)]
+    pub market_information: AccountInfo<'info>,
+    pub system_program: AccountInfo<'info>,
+    pub event_authority: AccountInfo<'info>,
+    pub program: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct UpdateMarketInformation<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub manager: Signer<'info>,
+    #[account(mut)]
+    pub market_information: AccountInfo<'info>,
+    pub system_program: AccountInfo<'info>,
+    pub event_authority: AccountInfo<'info>,
+    pub program: AccountInfo<'info>,
+}
+
+pub fn create_market_information<'a>(
+    ctx: CpiContext<'_, '_, '_, 'a, CreateMarketInformation<'a>>,
+    params: CreateMarketInformationParams,
+) -> Result<()> {
+    let ix = crate::instructions::loopscale::instruction::create_market_information(
+        ctx.program.key(),
+        params,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &ToAccountInfos::to_account_infos(&ctx),
+        ctx.signer_seeds,
+    )?;
+    Ok(())
+}
+
+pub fn update_market_information<'a>(
+    ctx: CpiContext<'_, '_, '_, 'a, UpdateMarketInformation<'a>>,
+    params: UpdateMarketInformationParams,
+) -> Result<()> {
+    let ix = crate::instructions::loopscale::instruction::update_market_information(
+        ctx.program.key(),
+        params,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &ToAccountInfos::to_account_infos(&ctx),
+        ctx.signer_seeds,
+    )?;
+    Ok(())
+} 

--- a/programs/invest-in-sol/src/instructions/cpi/loopscale/cpi/mod.rs
+++ b/programs/invest-in-sol/src/instructions/cpi/loopscale/cpi/mod.rs
@@ -1,0 +1,13 @@
+pub mod loan;
+pub mod collateral;
+pub mod strategy;
+pub mod vault;
+pub mod market;
+pub mod timelock;
+
+pub use loan::*;
+pub use collateral::*;
+pub use strategy::*;
+pub use vault::*;
+pub use market::*;
+pub use timelock::*; 

--- a/programs/invest-in-sol/src/instructions/cpi/loopscale/cpi/strategy.rs
+++ b/programs/invest-in-sol/src/instructions/cpi/loopscale/cpi/strategy.rs
@@ -1,0 +1,61 @@
+use anchor_lang::prelude::*;
+use crate::instructions::loopscale::types::{
+    accounts::*, instructions::*, pod::*,
+};
+
+#[derive(Accounts)]
+pub struct CreateStrategy<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub manager: Signer<'info>,
+    #[account(mut)]
+    pub strategy: AccountInfo<'info>,
+    pub principal_mint: AccountInfo<'info>,
+    pub system_program: AccountInfo<'info>,
+    pub event_authority: AccountInfo<'info>,
+    pub program: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct UpdateStrategy<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub manager: Signer<'info>,
+    #[account(mut)]
+    pub strategy: AccountInfo<'info>,
+    pub system_program: AccountInfo<'info>,
+    pub event_authority: AccountInfo<'info>,
+    pub program: AccountInfo<'info>,
+}
+
+pub fn create_strategy<'a>(
+    ctx: CpiContext<'_, '_, '_, 'a, CreateStrategy<'a>>,
+    params: CreateStrategyParams,
+) -> Result<()> {
+    let ix = crate::instructions::loopscale::instruction::create_strategy(
+        ctx.program.key(),
+        params,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &ToAccountInfos::to_account_infos(&ctx),
+        ctx.signer_seeds,
+    )?;
+    Ok(())
+}
+
+pub fn update_strategy<'a>(
+    ctx: CpiContext<'_, '_, '_, 'a, UpdateStrategy<'a>>,
+    params: UpdateStrategyParams,
+) -> Result<()> {
+    let ix = crate::instructions::loopscale::instruction::update_strategy(
+        ctx.program.key(),
+        params,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &ToAccountInfos::to_account_infos(&ctx),
+        ctx.signer_seeds,
+    )?;
+    Ok(())
+} 

--- a/programs/invest-in-sol/src/instructions/cpi/loopscale/cpi/timelock.rs
+++ b/programs/invest-in-sol/src/instructions/cpi/loopscale/cpi/timelock.rs
@@ -1,0 +1,90 @@
+use anchor_lang::prelude::*;
+use crate::instructions::loopscale::types::{
+    accounts::*, instructions::*, pod::*,
+};
+
+#[derive(Accounts)]
+pub struct CancelTimelock<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub manager: Signer<'info>,
+    #[account(mut)]
+    pub vault: AccountInfo<'info>,
+    #[account(mut)]
+    pub timelock: AccountInfo<'info>,
+    pub system_program: AccountInfo<'info>,
+    pub event_authority: AccountInfo<'info>,
+    pub program: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct CreateTimelock<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub manager: Signer<'info>,
+    #[account(mut)]
+    pub vault: AccountInfo<'info>,
+    #[account(mut)]
+    pub timelock: AccountInfo<'info>,
+    pub system_program: AccountInfo<'info>,
+    pub event_authority: AccountInfo<'info>,
+    pub program: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct ExecuteTimelock<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub manager: Signer<'info>,
+    #[account(mut)]
+    pub vault: AccountInfo<'info>,
+    #[account(mut)]
+    pub timelock: AccountInfo<'info>,
+    pub system_program: AccountInfo<'info>,
+    pub event_authority: AccountInfo<'info>,
+    pub program: AccountInfo<'info>,
+}
+
+pub fn cancel_timelock<'a>(
+    ctx: CpiContext<'_, '_, '_, 'a, CancelTimelock<'a>>,
+) -> Result<()> {
+    let ix = crate::instructions::loopscale::instruction::cancel_timelock(
+        ctx.program.key(),
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &ToAccountInfos::to_account_infos(&ctx),
+        ctx.signer_seeds,
+    )?;
+    Ok(())
+}
+
+pub fn create_timelock<'a>(
+    ctx: CpiContext<'_, '_, '_, 'a, CreateTimelock<'a>>,
+    params: CreateTimelockParams,
+) -> Result<()> {
+    let ix = crate::instructions::loopscale::instruction::create_timelock(
+        ctx.program.key(),
+        params,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &ToAccountInfos::to_account_infos(&ctx),
+        ctx.signer_seeds,
+    )?;
+    Ok(())
+}
+
+pub fn execute_timelock<'a>(
+    ctx: CpiContext<'_, '_, '_, 'a, ExecuteTimelock<'a>>,
+) -> Result<()> {
+    let ix = crate::instructions::loopscale::instruction::execute_timelock(
+        ctx.program.key(),
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &ToAccountInfos::to_account_infos(&ctx),
+        ctx.signer_seeds,
+    )?;
+    Ok(())
+} 

--- a/programs/invest-in-sol/src/instructions/cpi/loopscale/cpi/vault.rs
+++ b/programs/invest-in-sol/src/instructions/cpi/loopscale/cpi/vault.rs
@@ -1,0 +1,98 @@
+use anchor_lang::prelude::*;
+use crate::instructions::loopscale::types::{
+    accounts::*, instructions::*, pod::*,
+};
+
+#[derive(Accounts)]
+pub struct ClaimVaultFee<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub manager: Signer<'info>,
+    #[account(mut)]
+    pub vault: AccountInfo<'info>,
+    #[account(mut)]
+    pub strategy: AccountInfo<'info>,
+    pub principal_mint: AccountInfo<'info>,
+    #[account(mut)]
+    pub manager_principal_ta: AccountInfo<'info>,
+    #[account(mut)]
+    pub strategy_principal_ta: AccountInfo<'info>,
+    pub token_program: AccountInfo<'info>,
+    pub associated_token_program: AccountInfo<'info>,
+    pub system_program: AccountInfo<'info>,
+    pub event_authority: AccountInfo<'info>,
+    pub program: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct CreateVault<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub manager: Signer<'info>,
+    #[account(mut)]
+    pub vault: AccountInfo<'info>,
+    pub principal_mint: AccountInfo<'info>,
+    pub system_program: AccountInfo<'info>,
+    pub event_authority: AccountInfo<'info>,
+    pub program: AccountInfo<'info>,
+}
+
+#[derive(Accounts)]
+pub struct UpdateVault<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub manager: Signer<'info>,
+    #[account(mut)]
+    pub vault: AccountInfo<'info>,
+    pub system_program: AccountInfo<'info>,
+    pub event_authority: AccountInfo<'info>,
+    pub program: AccountInfo<'info>,
+}
+
+pub fn claim_vault_fee<'a>(
+    ctx: CpiContext<'_, '_, '_, 'a, ClaimVaultFee<'a>>,
+    params: ClaimVaultFeeParams,
+) -> Result<()> {
+    let ix = crate::instructions::loopscale::instruction::claim_vault_fee(
+        ctx.program.key(),
+        params,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &ToAccountInfos::to_account_infos(&ctx),
+        ctx.signer_seeds,
+    )?;
+    Ok(())
+}
+
+pub fn create_vault<'a>(
+    ctx: CpiContext<'_, '_, '_, 'a, CreateVault<'a>>,
+    params: CreateVaultParams,
+) -> Result<()> {
+    let ix = crate::instructions::loopscale::instruction::create_vault(
+        ctx.program.key(),
+        params,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &ToAccountInfos::to_account_infos(&ctx),
+        ctx.signer_seeds,
+    )?;
+    Ok(())
+}
+
+pub fn update_vault<'a>(
+    ctx: CpiContext<'_, '_, '_, 'a, UpdateVault<'a>>,
+    params: UpdateVaultParams,
+) -> Result<()> {
+    let ix = crate::instructions::loopscale::instruction::update_vault(
+        ctx.program.key(),
+        params,
+    )?;
+    solana_program::program::invoke_signed(
+        &ix,
+        &ToAccountInfos::to_account_infos(&ctx),
+        ctx.signer_seeds,
+    )?;
+    Ok(())
+} 

--- a/programs/invest-in-sol/src/instructions/cpi/loopscale/idl.json
+++ b/programs/invest-in-sol/src/instructions/cpi/loopscale/idl.json
@@ -1,0 +1,5233 @@
+{
+  "address": "1oopBoJG58DgkUVKkEzKgyG9dvRmpgeEm1AVjoHkF78",
+  "metadata": {
+    "name": "loopscale",
+    "version": "0.1.0",
+    "spec": "0.1.0",
+    "description": "Created with Anchor"
+  },
+  "instructions": [
+    {
+      "name": "borrow_principal",
+      "docs": [
+        "principal instructions",
+        "6.",
+        "6.1. borrow principal"
+      ],
+      "discriminator": [
+        106,
+        10,
+        38,
+        204,
+        139,
+        188,
+        124,
+        50
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "borrower",
+          "signer": true
+        },
+        {
+          "name": "loan",
+          "writable": true
+        },
+        {
+          "name": "strategy",
+          "writable": true
+        },
+        {
+          "name": "market_information"
+        },
+        {
+          "name": "principal_mint"
+        },
+        {
+          "name": "borrower_ta",
+          "writable": true
+        },
+        {
+          "name": "strategy_ta",
+          "writable": true
+        },
+        {
+          "name": "associated_token_program"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "system_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "BorrowPrincipalParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "cancel_timelock",
+      "docs": [
+        "9.2.3 timelock cancel"
+      ],
+      "discriminator": [
+        158,
+        180,
+        47,
+        81,
+        133,
+        231,
+        168,
+        238
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "manager",
+          "signer": true
+        },
+        {
+          "name": "vault",
+          "writable": true
+        },
+        {
+          "name": "timelock",
+          "writable": true
+        },
+        {
+          "name": "system_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "claim_vault_fee",
+      "docs": [
+        "9.1.2 vault manager actions"
+      ],
+      "discriminator": [
+        38,
+        40,
+        51,
+        195,
+        130,
+        248,
+        134,
+        247
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "manager",
+          "signer": true
+        },
+        {
+          "name": "vault",
+          "writable": true
+        },
+        {
+          "name": "strategy",
+          "writable": true
+        },
+        {
+          "name": "principal_mint"
+        },
+        {
+          "name": "manager_principal_ta",
+          "writable": true
+        },
+        {
+          "name": "strategy_principal_ta",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "associated_token_program"
+        },
+        {
+          "name": "system_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "ClaimVaultFeeParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "close_loop",
+      "docs": [
+        "1.3 close loop"
+      ],
+      "discriminator": [
+        98,
+        248,
+        86,
+        17,
+        177,
+        225,
+        29,
+        138
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "borrower",
+          "signer": true
+        },
+        {
+          "name": "loan",
+          "writable": true
+        },
+        {
+          "name": "strategy",
+          "writable": true
+        },
+        {
+          "name": "principal_mint"
+        },
+        {
+          "name": "collateral_mint"
+        },
+        {
+          "name": "borrower_collateral_ta",
+          "writable": true
+        },
+        {
+          "name": "loan_collateral_ta",
+          "writable": true
+        },
+        {
+          "name": "borrower_principal_ta",
+          "writable": true
+        },
+        {
+          "name": "strategy_principal_ta",
+          "writable": true
+        },
+        {
+          "name": "principal_token_program"
+        },
+        {
+          "name": "collateral_token_program"
+        },
+        {
+          "name": "associated_token_program"
+        },
+        {
+          "name": "system_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "CloseLoopParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "close_strategy",
+      "docs": [
+        "8.5 close strategy"
+      ],
+      "discriminator": [
+        56,
+        247,
+        170,
+        246,
+        89,
+        221,
+        134,
+        200
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "lender",
+          "signer": true
+        },
+        {
+          "name": "strategy",
+          "writable": true
+        },
+        {
+          "name": "principal_mint"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "associated_token_program"
+        },
+        {
+          "name": "system_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "create_loan",
+      "docs": [
+        "creditbook instructionss",
+        "",
+        "1. loan instructions",
+        "1.1 create loan"
+      ],
+      "discriminator": [
+        166,
+        131,
+        118,
+        219,
+        138,
+        218,
+        206,
+        140
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "borrower",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "loan",
+          "writable": true
+        },
+        {
+          "name": "strategy",
+          "writable": true
+        },
+        {
+          "name": "market_information"
+        },
+        {
+          "name": "principal_mint"
+        },
+        {
+          "name": "collateral_mint"
+        },
+        {
+          "name": "borrower_principal_ta",
+          "writable": true
+        },
+        {
+          "name": "strategy_principal_ta",
+          "writable": true
+        },
+        {
+          "name": "borrower_collateral_ta",
+          "writable": true
+        },
+        {
+          "name": "loan_collateral_ta",
+          "writable": true
+        },
+        {
+          "name": "principal_token_program"
+        },
+        {
+          "name": "collateral_token_program"
+        },
+        {
+          "name": "associated_token_program"
+        },
+        {
+          "name": "system_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "CreateLoanParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "create_market_information",
+      "docs": [
+        "7. oracle instructions",
+        "7.1 create market information account"
+      ],
+      "discriminator": [
+        246,
+        45,
+        227,
+        173,
+        15,
+        51,
+        85,
+        1
+      ],
+      "accounts": [
+        {
+          "name": "market_information",
+          "writable": true
+        },
+        {
+          "name": "system_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "CreateMarketInformationParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "create_strategy",
+      "docs": [
+        "8. strategy instructions",
+        "8.1 create strategy"
+      ],
+      "discriminator": [
+        152,
+        160,
+        107,
+        148,
+        245,
+        190,
+        127,
+        224
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "nonce",
+          "signer": true
+        },
+        {
+          "name": "strategy",
+          "writable": true
+        },
+        {
+          "name": "market_information"
+        },
+        {
+          "name": "principal_mint"
+        },
+        {
+          "name": "system_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "CreateStrategyParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "create_timelock",
+      "docs": [
+        "9.2 timelock instructions",
+        "9.2.1 timelock create"
+      ],
+      "discriminator": [
+        243,
+        10,
+        110,
+        170,
+        71,
+        251,
+        210,
+        87
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "manager",
+          "signer": true
+        },
+        {
+          "name": "vault",
+          "writable": true
+        },
+        {
+          "name": "timelock",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "market_information",
+          "writable": true
+        },
+        {
+          "name": "system_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "TimelockUpdateParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "create_vault",
+      "docs": [
+        "9.3 create vault"
+      ],
+      "discriminator": [
+        29,
+        237,
+        247,
+        208,
+        193,
+        82,
+        54,
+        135
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "nonce",
+          "signer": true
+        },
+        {
+          "name": "principal_mint"
+        },
+        {
+          "name": "lp_mint",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "vault",
+          "writable": true
+        },
+        {
+          "name": "strategy",
+          "writable": true
+        },
+        {
+          "name": "market_information",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "system_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "CreateVaultParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "deposit_collateral",
+      "docs": [
+        "collateral instructions",
+        "5.",
+        "5.1. deposit collateral"
+      ],
+      "discriminator": [
+        156,
+        131,
+        142,
+        116,
+        146,
+        247,
+        162,
+        120
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "borrower",
+          "signer": true
+        },
+        {
+          "name": "loan",
+          "writable": true
+        },
+        {
+          "name": "borrower_collateral_ta",
+          "writable": true
+        },
+        {
+          "name": "loan_collateral_ta",
+          "writable": true
+        },
+        {
+          "name": "deposit_mint"
+        },
+        {
+          "name": "system_program"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "associated_token_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "DepositCollateralParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "deposit_strategy",
+      "docs": [
+        "8.2 deposit strategy"
+      ],
+      "discriminator": [
+        246,
+        82,
+        57,
+        226,
+        131,
+        222,
+        253,
+        249
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "lender",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "strategy",
+          "writable": true
+        },
+        {
+          "name": "principal_mint"
+        },
+        {
+          "name": "lender_ta",
+          "writable": true
+        },
+        {
+          "name": "strategy_ta",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "associated_token_program"
+        },
+        {
+          "name": "system_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "deposit_user_vault",
+      "docs": [
+        "9. vault instructions",
+        "9.1 vault actions",
+        "9.1.1 vault user actions",
+        "9.1.1.1 vault user deposit"
+      ],
+      "discriminator": [
+        204,
+        190,
+        182,
+        224,
+        15,
+        219,
+        247,
+        121
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "user",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "vault",
+          "writable": true
+        },
+        {
+          "name": "strategy",
+          "writable": true
+        },
+        {
+          "name": "lp_mint",
+          "writable": true
+        },
+        {
+          "name": "user_lp_ta",
+          "writable": true
+        },
+        {
+          "name": "user_principal_ta",
+          "writable": true
+        },
+        {
+          "name": "strategy_principal_ta",
+          "writable": true
+        },
+        {
+          "name": "principal_mint"
+        },
+        {
+          "name": "principal_token_program"
+        },
+        {
+          "name": "token_2022_program"
+        },
+        {
+          "name": "associated_token_program"
+        },
+        {
+          "name": "system_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "LpParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "execute_timelock",
+      "docs": [
+        "9.2.2 timelock execute"
+      ],
+      "discriminator": [
+        160,
+        194,
+        240,
+        8,
+        212,
+        93,
+        157,
+        221
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "vault",
+          "writable": true
+        },
+        {
+          "name": "timelock",
+          "writable": true
+        },
+        {
+          "name": "strategy",
+          "writable": true
+        },
+        {
+          "name": "market_information",
+          "writable": true
+        },
+        {
+          "name": "strategy_ta",
+          "writable": true
+        },
+        {
+          "name": "system_program"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "associated_token_program"
+        },
+        {
+          "name": "principal_mint"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "liquidate_ledger",
+      "docs": [
+        "2. liquidate ledger"
+      ],
+      "discriminator": [
+        5,
+        124,
+        101,
+        85,
+        254,
+        175,
+        184,
+        249
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "liquidator",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "borrower",
+          "writable": true
+        },
+        {
+          "name": "loan",
+          "writable": true
+        },
+        {
+          "name": "strategy",
+          "writable": true
+        },
+        {
+          "name": "market_information"
+        },
+        {
+          "name": "liquidator_ta",
+          "writable": true
+        },
+        {
+          "name": "strategy_ta",
+          "writable": true
+        },
+        {
+          "name": "principal_mint"
+        },
+        {
+          "name": "associated_token_program"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "token_2022_program"
+        },
+        {
+          "name": "system_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "LiquidateLedgerParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "manage_collateral_claim_orca_fee",
+      "docs": [
+        "manage collateral instructions",
+        "5.3",
+        "5.3.1 orca claim fee"
+      ],
+      "discriminator": [
+        242,
+        48,
+        127,
+        91,
+        24,
+        187,
+        211,
+        234
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "borrower",
+          "signer": true
+        },
+        {
+          "name": "loan"
+        },
+        {
+          "name": "whirlpool",
+          "writable": true
+        },
+        {
+          "name": "token_vault_a",
+          "writable": true
+        },
+        {
+          "name": "token_vault_b",
+          "writable": true
+        },
+        {
+          "name": "tick_array_lower",
+          "writable": true
+        },
+        {
+          "name": "tick_array_upper",
+          "writable": true
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "position_token_account",
+          "writable": true
+        },
+        {
+          "name": "borrower_ta_a",
+          "writable": true
+        },
+        {
+          "name": "borrower_ta_b",
+          "writable": true
+        },
+        {
+          "name": "loan_ta_a",
+          "writable": true
+        },
+        {
+          "name": "loan_ta_b",
+          "writable": true
+        },
+        {
+          "name": "mint_a"
+        },
+        {
+          "name": "mint_b"
+        },
+        {
+          "name": "whirlpool_program"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "token_2022_program"
+        },
+        {
+          "name": "associated_token_program"
+        },
+        {
+          "name": "system_program"
+        },
+        {
+          "name": "memo_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "close_ta",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "manage_collateral_increase_orca_liquidity",
+      "docs": [
+        "5.3.2 orca increase liquidity"
+      ],
+      "discriminator": [
+        173,
+        62,
+        204,
+        113,
+        206,
+        27,
+        147,
+        128
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "borrower",
+          "signer": true
+        },
+        {
+          "name": "loan"
+        },
+        {
+          "name": "whirlpool",
+          "writable": true
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "position_token_account"
+        },
+        {
+          "name": "tick_array_lower",
+          "writable": true
+        },
+        {
+          "name": "tick_array_upper",
+          "writable": true
+        },
+        {
+          "name": "token_vault_a",
+          "writable": true
+        },
+        {
+          "name": "token_vault_b",
+          "writable": true
+        },
+        {
+          "name": "borrower_ta_a",
+          "writable": true
+        },
+        {
+          "name": "borrower_ta_b",
+          "writable": true
+        },
+        {
+          "name": "loan_ta_a",
+          "writable": true
+        },
+        {
+          "name": "loan_ta_b",
+          "writable": true
+        },
+        {
+          "name": "mint_a"
+        },
+        {
+          "name": "mint_b"
+        },
+        {
+          "name": "whirlpool_program"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "token_2022_program"
+        },
+        {
+          "name": "associated_token_program"
+        },
+        {
+          "name": "system_program"
+        },
+        {
+          "name": "memo_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "ManageOrcaLiquidityParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "manage_collateral_transfer_orca_position",
+      "docs": [
+        "5.3.4 orca transfer position"
+      ],
+      "discriminator": [
+        85,
+        151,
+        110,
+        243,
+        164,
+        41,
+        62,
+        238
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "borrower",
+          "signer": true
+        },
+        {
+          "name": "loan",
+          "writable": true
+        },
+        {
+          "name": "whirlpool",
+          "writable": true
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "position_token_account",
+          "writable": true
+        },
+        {
+          "name": "position_mint",
+          "writable": true
+        },
+        {
+          "name": "tick_array_lower",
+          "writable": true
+        },
+        {
+          "name": "tick_array_upper",
+          "writable": true
+        },
+        {
+          "name": "new_tick_array_lower",
+          "writable": true
+        },
+        {
+          "name": "new_tick_array_upper",
+          "writable": true
+        },
+        {
+          "name": "token_vault_a",
+          "writable": true
+        },
+        {
+          "name": "token_vault_b",
+          "writable": true
+        },
+        {
+          "name": "borrower_ta_a",
+          "writable": true
+        },
+        {
+          "name": "borrower_ta_b",
+          "writable": true
+        },
+        {
+          "name": "loan_ta_a",
+          "writable": true
+        },
+        {
+          "name": "loan_ta_b",
+          "writable": true
+        },
+        {
+          "name": "new_position",
+          "writable": true
+        },
+        {
+          "name": "new_position_mint",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "new_position_token_account",
+          "writable": true
+        },
+        {
+          "name": "mint_a"
+        },
+        {
+          "name": "mint_b"
+        },
+        {
+          "name": "metadata_update_auth"
+        },
+        {
+          "name": "whirlpool_program"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "token_2022_program"
+        },
+        {
+          "name": "associated_token_program"
+        },
+        {
+          "name": "system_program"
+        },
+        {
+          "name": "memo_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "TransferOrcaPositionParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "manage_collateral_withdraw_orca_liquidity",
+      "docs": [
+        "5.3.3 orca withdraw liquidity"
+      ],
+      "discriminator": [
+        219,
+        89,
+        35,
+        158,
+        224,
+        12,
+        200,
+        90
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "borrower",
+          "signer": true
+        },
+        {
+          "name": "loan"
+        },
+        {
+          "name": "whirlpool",
+          "writable": true
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "position_token_account"
+        },
+        {
+          "name": "tick_array_lower",
+          "writable": true
+        },
+        {
+          "name": "tick_array_upper",
+          "writable": true
+        },
+        {
+          "name": "token_vault_a",
+          "writable": true
+        },
+        {
+          "name": "token_vault_b",
+          "writable": true
+        },
+        {
+          "name": "borrower_ta_a",
+          "writable": true
+        },
+        {
+          "name": "borrower_ta_b",
+          "writable": true
+        },
+        {
+          "name": "loan_ta_a",
+          "writable": true
+        },
+        {
+          "name": "loan_ta_b",
+          "writable": true
+        },
+        {
+          "name": "mint_a"
+        },
+        {
+          "name": "mint_b"
+        },
+        {
+          "name": "whirlpool_program"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "token_2022_program"
+        },
+        {
+          "name": "associated_token_program"
+        },
+        {
+          "name": "system_program"
+        },
+        {
+          "name": "memo_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "ManageOrcaLiquidityParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "open_loop",
+      "docs": [
+        "1.2 open loop"
+      ],
+      "discriminator": [
+        153,
+        236,
+        150,
+        30,
+        36,
+        2,
+        246,
+        20
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "borrower",
+          "signer": true
+        },
+        {
+          "name": "loan",
+          "writable": true
+        },
+        {
+          "name": "strategy",
+          "writable": true
+        },
+        {
+          "name": "market_information"
+        },
+        {
+          "name": "principal_mint"
+        },
+        {
+          "name": "collateral_mint"
+        },
+        {
+          "name": "borrower_principal_ta",
+          "writable": true
+        },
+        {
+          "name": "strategy_principal_ta",
+          "writable": true
+        },
+        {
+          "name": "borrower_collateral_ta",
+          "writable": true
+        },
+        {
+          "name": "loan_collateral_ta",
+          "writable": true
+        },
+        {
+          "name": "principal_token_program"
+        },
+        {
+          "name": "collateral_token_program"
+        },
+        {
+          "name": "associated_token_program"
+        },
+        {
+          "name": "system_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "OpenLoopParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "refinance_ledger",
+      "docs": [
+        "3. refinance ledger"
+      ],
+      "discriminator": [
+        103,
+        41,
+        134,
+        43,
+        140,
+        152,
+        253,
+        74
+      ],
+      "accounts": [
+        {
+          "name": "bs_auth",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "loan",
+          "writable": true
+        },
+        {
+          "name": "old_strategy",
+          "writable": true
+        },
+        {
+          "name": "new_strategy",
+          "writable": true
+        },
+        {
+          "name": "old_strategy_ta",
+          "writable": true
+        },
+        {
+          "name": "new_strategy_ta",
+          "writable": true
+        },
+        {
+          "name": "old_strategy_market_information"
+        },
+        {
+          "name": "new_strategy_market_information"
+        },
+        {
+          "name": "principal_mint"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "associated_token_program"
+        },
+        {
+          "name": "system_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "RefinanceLedgerParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "repay_principal",
+      "docs": [
+        "6.2. repay principal"
+      ],
+      "discriminator": [
+        229,
+        67,
+        83,
+        65,
+        77,
+        84,
+        80,
+        141
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "borrower",
+          "signer": true
+        },
+        {
+          "name": "loan",
+          "writable": true
+        },
+        {
+          "name": "strategy",
+          "writable": true
+        },
+        {
+          "name": "principal_mint"
+        },
+        {
+          "name": "borrower_ta",
+          "writable": true
+        },
+        {
+          "name": "strategy_ta",
+          "writable": true
+        },
+        {
+          "name": "associated_token_program"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "system_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "RepayPrincipalParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "sell_ledger",
+      "docs": [
+        "4. sell ledger"
+      ],
+      "discriminator": [
+        55,
+        17,
+        153,
+        148,
+        120,
+        242,
+        80,
+        5
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "lender_auth",
+          "signer": true
+        },
+        {
+          "name": "loan",
+          "writable": true
+        },
+        {
+          "name": "new_strategy_ta",
+          "writable": true
+        },
+        {
+          "name": "lender_auth_ta",
+          "writable": true
+        },
+        {
+          "name": "old_strategy",
+          "writable": true
+        },
+        {
+          "name": "new_strategy",
+          "writable": true
+        },
+        {
+          "name": "old_strategy_market_information"
+        },
+        {
+          "name": "new_strategy_market_information"
+        },
+        {
+          "name": "principal_mint"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "associated_token_program"
+        },
+        {
+          "name": "system_program"
+        },
+        {
+          "name": "vault",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "old_strategy_ta",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "SellLedgerParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "stake_user_vault_lp",
+      "docs": [
+        "9.1.1.3 vault user stake"
+      ],
+      "discriminator": [
+        114,
+        132,
+        194,
+        209,
+        208,
+        149,
+        43,
+        136
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "user",
+          "signer": true
+        },
+        {
+          "name": "nonce",
+          "signer": true
+        },
+        {
+          "name": "vault",
+          "writable": true
+        },
+        {
+          "name": "vault_stake",
+          "writable": true
+        },
+        {
+          "name": "lp_mint"
+        },
+        {
+          "name": "user_lp_ta",
+          "writable": true
+        },
+        {
+          "name": "vault_stake_lp_ta",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "associated_token_program"
+        },
+        {
+          "name": "system_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "VaultStakeParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "unstake_user_vault_lp",
+      "docs": [
+        "9.1.1.4 vault user unstake"
+      ],
+      "discriminator": [
+        83,
+        78,
+        230,
+        123,
+        226,
+        40,
+        158,
+        97
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "user",
+          "signer": true
+        },
+        {
+          "name": "vault",
+          "writable": true
+        },
+        {
+          "name": "lp_mint",
+          "writable": true
+        },
+        {
+          "name": "vault_stake",
+          "writable": true
+        },
+        {
+          "name": "user_lp_ta",
+          "writable": true
+        },
+        {
+          "name": "vault_stake_lp_ta",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "associated_token_program"
+        },
+        {
+          "name": "system_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "update_market_information",
+      "docs": [
+        "7.2 update market information account"
+      ],
+      "discriminator": [
+        186,
+        195,
+        82,
+        187,
+        196,
+        199,
+        135,
+        158
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "market_information",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "vec": {
+              "defined": {
+                "name": "UpdateMarketInformationParams"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "update_strategy",
+      "docs": [
+        "8.3 update strategy"
+      ],
+      "discriminator": [
+        16,
+        76,
+        138,
+        179,
+        171,
+        112,
+        196,
+        21
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "lender",
+          "signer": true
+        },
+        {
+          "name": "strategy",
+          "writable": true
+        },
+        {
+          "name": "principal_mint"
+        },
+        {
+          "name": "strategy_ta",
+          "writable": true
+        },
+        {
+          "name": "system_program"
+        },
+        {
+          "name": "associated_token_program"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "collateral_terms",
+          "type": {
+            "vec": {
+              "defined": {
+                "name": "MultiCollateralTermsUpdateParams"
+              }
+            }
+          }
+        },
+        {
+          "name": "params",
+          "type": {
+            "option": {
+              "defined": {
+                "name": "UpdateStrategyParams"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "update_vault",
+      "docs": [
+        "9.4 toggle vault deposits"
+      ],
+      "discriminator": [
+        67,
+        229,
+        185,
+        188,
+        226,
+        11,
+        210,
+        60
+      ],
+      "accounts": [
+        {
+          "name": "manager",
+          "signer": true
+        },
+        {
+          "name": "vault",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "UpdateVaultParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "withdraw_collateral",
+      "docs": [
+        "5.2. withdraw collateral"
+      ],
+      "discriminator": [
+        115,
+        135,
+        168,
+        106,
+        139,
+        214,
+        138,
+        150
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "borrower",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "loan",
+          "writable": true
+        },
+        {
+          "name": "borrower_ta",
+          "writable": true
+        },
+        {
+          "name": "loan_ta",
+          "writable": true
+        },
+        {
+          "name": "system_program"
+        },
+        {
+          "name": "asset_mint"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "associated_token_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "WithdrawCollateralParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "withdraw_strategy",
+      "docs": [
+        "8.4 withdraw strategy"
+      ],
+      "discriminator": [
+        31,
+        45,
+        162,
+        5,
+        193,
+        217,
+        134,
+        188
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "lender",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "strategy",
+          "writable": true
+        },
+        {
+          "name": "principal_mint"
+        },
+        {
+          "name": "lender_ta",
+          "writable": true
+        },
+        {
+          "name": "strategy_ta",
+          "writable": true
+        },
+        {
+          "name": "associated_token_program"
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "system_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "withdraw_all",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "withdraw_user_vault",
+      "docs": [
+        "9.1.1.2 vault user withdraw"
+      ],
+      "discriminator": [
+        9,
+        80,
+        134,
+        138,
+        212,
+        20,
+        61,
+        42
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "user",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "vault",
+          "writable": true
+        },
+        {
+          "name": "strategy",
+          "writable": true
+        },
+        {
+          "name": "lp_mint",
+          "writable": true
+        },
+        {
+          "name": "user_lp_ta",
+          "writable": true
+        },
+        {
+          "name": "user_principal_ta",
+          "writable": true
+        },
+        {
+          "name": "strategy_principal_ta",
+          "writable": true
+        },
+        {
+          "name": "principal_mint"
+        },
+        {
+          "name": "principal_token_program"
+        },
+        {
+          "name": "token_2022_program"
+        },
+        {
+          "name": "associated_token_program"
+        },
+        {
+          "name": "system_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "LpParams"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "Loan",
+      "discriminator": [
+        20,
+        195,
+        70,
+        117,
+        165,
+        227,
+        182,
+        1
+      ]
+    },
+    {
+      "name": "MarketInformation",
+      "discriminator": [
+        194,
+        154,
+        190,
+        99,
+        64,
+        111,
+        37,
+        205
+      ]
+    },
+    {
+      "name": "Position",
+      "discriminator": [
+        170,
+        188,
+        143,
+        228,
+        122,
+        64,
+        247,
+        208
+      ]
+    },
+    {
+      "name": "Strategy",
+      "discriminator": [
+        174,
+        110,
+        39,
+        119,
+        82,
+        106,
+        169,
+        102
+      ]
+    },
+    {
+      "name": "Timelock",
+      "discriminator": [
+        189,
+        33,
+        78,
+        75,
+        205,
+        31,
+        4,
+        177
+      ]
+    },
+    {
+      "name": "Vault",
+      "discriminator": [
+        211,
+        8,
+        232,
+        43,
+        2,
+        152,
+        117,
+        119
+      ]
+    },
+    {
+      "name": "VaultStake",
+      "discriminator": [
+        225,
+        34,
+        128,
+        53,
+        167,
+        239,
+        182,
+        107
+      ]
+    },
+    {
+      "name": "Whirlpool",
+      "discriminator": [
+        63,
+        149,
+        209,
+        12,
+        225,
+        128,
+        99,
+        9
+      ]
+    }
+  ],
+  "events": [
+    {
+      "name": "TimelockCanceledEvent",
+      "discriminator": [
+        67,
+        213,
+        255,
+        46,
+        1,
+        27,
+        230,
+        3
+      ]
+    },
+    {
+      "name": "TimelockCreatedEvent",
+      "discriminator": [
+        152,
+        153,
+        7,
+        180,
+        31,
+        147,
+        228,
+        201
+      ]
+    },
+    {
+      "name": "TimelockExecutedEvent",
+      "discriminator": [
+        163,
+        211,
+        23,
+        234,
+        156,
+        203,
+        136,
+        240
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "InvalidCollateralMintOrIdentifier",
+      "msg": "The collateral mint specified does not match identifier according to type"
+    },
+    {
+      "code": 6001,
+      "name": "MaintanenceCollateralNotMet",
+      "msg": "Loan doesnt have enough collateral for maintenance"
+    },
+    {
+      "code": 6002,
+      "name": "ArithmeticOverflow",
+      "msg": "Arithmetic overflow"
+    },
+    {
+      "code": 6003,
+      "name": "InvalidTimestamp",
+      "msg": "Invalid timestamp"
+    },
+    {
+      "code": 6004,
+      "name": "MaxCollateralReached",
+      "msg": "Max Collateral reached"
+    },
+    {
+      "code": 6005,
+      "name": "PartialWithdrawsNotAllowedForOrcaPositions",
+      "msg": "Partial withdraws not allowed for orca positions"
+    },
+    {
+      "code": 6006,
+      "name": "InvalidLedgerStatusForRefinance",
+      "msg": "Invalid ledger status for refinance"
+    },
+    {
+      "code": 6007,
+      "name": "InvalidLedgerStatusForLedgerSale",
+      "msg": "Invalid ledger status for ledger sale"
+    },
+    {
+      "code": 6008,
+      "name": "InvalidMarketInformation",
+      "msg": "Invalid market information"
+    },
+    {
+      "code": 6009,
+      "name": "LoanSizeExceedsMaxOriginationSize",
+      "msg": "Loan size exceeds max origination size"
+    },
+    {
+      "code": 6010,
+      "name": "InvalidManager",
+      "msg": "Invalid manager"
+    },
+    {
+      "code": 6011,
+      "name": "NoOpenLedgers",
+      "msg": "No open ledgers"
+    },
+    {
+      "code": 6012,
+      "name": "InvalidDurationIndex",
+      "msg": "Invalid duration index"
+    },
+    {
+      "code": 6013,
+      "name": "InvalidAssetIdentifier",
+      "msg": "Invalid asset identifier"
+    },
+    {
+      "code": 6014,
+      "name": "APYDisabled",
+      "msg": "APY is disabled"
+    },
+    {
+      "code": 6015,
+      "name": "CollateralNotPresent",
+      "msg": "Collateral not present"
+    },
+    {
+      "code": 6016,
+      "name": "InvalidPrincipalMint",
+      "msg": "Invalid principal mint"
+    },
+    {
+      "code": 6017,
+      "name": "InvalidLedgerStrategy",
+      "msg": "Invalid ledger strategy"
+    },
+    {
+      "code": 6018,
+      "name": "InvalidLedgerIndex",
+      "msg": "Invalid ledger index"
+    },
+    {
+      "code": 6019,
+      "name": "NoSupportedCollateralFound",
+      "msg": "No supported collateral found"
+    },
+    {
+      "code": 6020,
+      "name": "CannotSellToSameStrategy",
+      "msg": "Cannot sell to same strategy"
+    },
+    {
+      "code": 6021,
+      "name": "InvalidOracleAccount",
+      "msg": "Invalid Oracle account"
+    },
+    {
+      "code": 6022,
+      "name": "InvalidLegacyPythAccount",
+      "msg": "Invalid Legacy Pyth account"
+    },
+    {
+      "code": 6023,
+      "name": "InvalidPriceExpo",
+      "msg": "Invalid price exponent"
+    },
+    {
+      "code": 6024,
+      "name": "StalePythPrice",
+      "msg": "Stale Pyth price"
+    },
+    {
+      "code": 6025,
+      "name": "PriceUncertainityExceeded",
+      "msg": "Price uncertainilty is more than max uncertainity"
+    },
+    {
+      "code": 6026,
+      "name": "NegativePrice",
+      "msg": "Price cannot be negative"
+    },
+    {
+      "code": 6027,
+      "name": "PriceOverflow",
+      "msg": "Price overflow"
+    },
+    {
+      "code": 6028,
+      "name": "MissingMarketInformationAccount",
+      "msg": "Missing Oracle Information account in remaining accounts"
+    },
+    {
+      "code": 6029,
+      "name": "MissingOracleAccount",
+      "msg": "Missing Oracle account in remaining accounts"
+    },
+    {
+      "code": 6030,
+      "name": "InvalidSeeds",
+      "msg": "Invalid seeds provided"
+    },
+    {
+      "code": 6031,
+      "name": "InvalidLoanVault",
+      "msg": "Invalid loan vault"
+    },
+    {
+      "code": 6032,
+      "name": "LoanNotInDefault",
+      "msg": "Loan not in default"
+    },
+    {
+      "code": 6033,
+      "name": "OrderStatusMismatch",
+      "msg": "Order status must be filled"
+    },
+    {
+      "code": 6034,
+      "name": "LSTOracleInvalid",
+      "msg": "LST Oracle invalid"
+    },
+    {
+      "code": 6035,
+      "name": "LSTOraclePriceNotFound",
+      "msg": "Could not get price per LST"
+    },
+    {
+      "code": 6036,
+      "name": "StaleLSTPrice",
+      "msg": "Stale LST price"
+    },
+    {
+      "code": 6037,
+      "name": "InvalidDecimal",
+      "msg": "value could not be converted to Decimal"
+    },
+    {
+      "code": 6038,
+      "name": "InvalidConversionOracleQuote",
+      "msg": "Invalid quote mint for conversion oracle"
+    },
+    {
+      "code": 6039,
+      "name": "MissingConversionRate",
+      "msg": "Missing conversion rate"
+    },
+    {
+      "code": 6040,
+      "name": "NotEnoughRemainingAccounts",
+      "msg": "Not enough remaining accounts passed in. Each lockbox asset requires at least 2 remaining accounts"
+    },
+    {
+      "code": 6041,
+      "name": "InvalidQuoteMintForMeteoraVault",
+      "msg": "Invalid quote mint for vault oracle. Must be the same as vault base token"
+    },
+    {
+      "code": 6042,
+      "name": "InvalidBaseMintForMeteoraVault",
+      "msg": "Invalid base mint for vault oracle. Must be the same as vault LP token"
+    },
+    {
+      "code": 6043,
+      "name": "InvalidDecimalsForMeteoraVault",
+      "msg": "Invalid decimals for vault oracle. Must be the same as vault LP token"
+    },
+    {
+      "code": 6044,
+      "name": "MeteoraVaultTotalAmountErr",
+      "msg": "Could not calculate total amount for meteroa vault"
+    },
+    {
+      "code": 6045,
+      "name": "InvalidExtraAccounts",
+      "msg": "Not enough extra accounts"
+    },
+    {
+      "code": 6046,
+      "name": "InvalidSwitchboardAccountOwner",
+      "msg": "Invalid switchboard account owner"
+    },
+    {
+      "code": 6047,
+      "name": "InvalidSwitchboardAccount",
+      "msg": "Invalid switchboard account"
+    },
+    {
+      "code": 6048,
+      "name": "InvalidOrcaAccountOwner",
+      "msg": "Invalid orca account owner"
+    },
+    {
+      "code": 6049,
+      "name": "InvalidOrcaPosition",
+      "msg": "Invalid orca position"
+    },
+    {
+      "code": 6050,
+      "name": "InvalidOrcaWhirlpool",
+      "msg": "Invalid orca whirlpool"
+    },
+    {
+      "code": 6051,
+      "name": "InvalidOrcaTickArray",
+      "msg": "Invalid orca tick array"
+    },
+    {
+      "code": 6052,
+      "name": "PositionDoesNotMatchWhirlpool",
+      "msg": "Position does not match whirlpool"
+    },
+    {
+      "code": 6053,
+      "name": "PositionDoesNotMatchMint",
+      "msg": "Position does not match mint"
+    },
+    {
+      "code": 6054,
+      "name": "TickArrayDoesNotMatchWhirlpool",
+      "msg": "Tick array does not match whirlpool"
+    },
+    {
+      "code": 6055,
+      "name": "MintDoesNotMatchWhirlpool",
+      "msg": "Mint does not match whirlpool"
+    },
+    {
+      "code": 6056,
+      "name": "InvalidPythAccount",
+      "msg": "Invalid Pyth account"
+    },
+    {
+      "code": 6057,
+      "name": "InvalidLtvData",
+      "msg": "Invalid LTV data"
+    },
+    {
+      "code": 6058,
+      "name": "LtvDataNotFound",
+      "msg": "Ltv data not found"
+    },
+    {
+      "code": 6059,
+      "name": "InvalidMintType",
+      "msg": "Invalid mint type for oracle"
+    },
+    {
+      "code": 6060,
+      "name": "InvalidMeteoraPool",
+      "msg": "Invalid meteora pool"
+    },
+    {
+      "code": 6061,
+      "name": "InvalidLPAccount",
+      "msg": "Invalid LP account"
+    },
+    {
+      "code": 6062,
+      "name": "UnsupportedCurveType",
+      "msg": "Unsupported curve type"
+    },
+    {
+      "code": 6063,
+      "name": "SwapSimulationFailed",
+      "msg": "Swap simulation failed"
+    },
+    {
+      "code": 6064,
+      "name": "InvalidBaseMintForFLP",
+      "msg": "Invalid base mint for FLP"
+    },
+    {
+      "code": 6065,
+      "name": "FLPPoolNotSupported",
+      "msg": "FLP pool not supported"
+    },
+    {
+      "code": 6066,
+      "name": "InvalidAssetIndex",
+      "msg": "Invalid asset index"
+    },
+    {
+      "code": 6067,
+      "name": "InvalidAssetIndexGuidance",
+      "msg": "Invalid asset index guidance"
+    },
+    {
+      "code": 6068,
+      "name": "PriceNotFound",
+      "msg": "Quote price not found in cache"
+    },
+    {
+      "code": 6069,
+      "name": "DuplicateCollateralMintsInMarketInformation",
+      "msg": "Duplicate collateral mints in market information"
+    },
+    {
+      "code": 6070,
+      "name": "MarketInformationFull",
+      "msg": "Market information is full"
+    },
+    {
+      "code": 6071,
+      "name": "AssetNotFoundInMarketInformation",
+      "msg": "Asset not found in market information"
+    },
+    {
+      "code": 6072,
+      "name": "MarketInformationAlreadyExists",
+      "msg": "Market information already exists"
+    },
+    {
+      "code": 6073,
+      "name": "InvalidVaultStrategy",
+      "msg": "Invalid vault strategy"
+    },
+    {
+      "code": 6074,
+      "name": "LedgerHealthy",
+      "msg": "Cannot liquidate a healthy ledger"
+    },
+    {
+      "code": 6075,
+      "name": "InvalidLiquidation",
+      "msg": "Invalid liquidation"
+    },
+    {
+      "code": 6076,
+      "name": "InsufficientLiquidity",
+      "msg": "Liquidity buffer has been exceeded"
+    },
+    {
+      "code": 6077,
+      "name": "InterestNotAccrued",
+      "msg": "Interest not accrued"
+    },
+    {
+      "code": 6078,
+      "name": "InvalidInterestPerSecondForClose",
+      "msg": "Invalid interest per second. Must be 0"
+    },
+    {
+      "code": 6079,
+      "name": "InvalidExternalYieldAmountForClose",
+      "msg": "Invalid external yield amount. Must be 0"
+    },
+    {
+      "code": 6080,
+      "name": "InvalidCurrentDeployedAmountForClose",
+      "msg": "Invalid current deployed amount. Must be 0"
+    },
+    {
+      "code": 6081,
+      "name": "InvalidTokenBalanceForClose",
+      "msg": "Invalid token balance. Must be 0"
+    },
+    {
+      "code": 6082,
+      "name": "InvalidFeeClaimableForClose",
+      "msg": "Invalid fee claimable. Must be 0"
+    },
+    {
+      "code": 6083,
+      "name": "InvalidLender",
+      "msg": "Invalid lender"
+    },
+    {
+      "code": 6084,
+      "name": "SaleSlippageExceeded",
+      "msg": "Sale slippage exceeded"
+    },
+    {
+      "code": 6085,
+      "name": "ExpectedLtvMismatch",
+      "msg": "Expected LTV mismatch"
+    },
+    {
+      "code": 6086,
+      "name": "ExpectedLqtMismatch",
+      "msg": "Expected LQT mismatch"
+    },
+    {
+      "code": 6087,
+      "name": "ExpectedApyMismatch",
+      "msg": "Expected APY mismatch"
+    },
+    {
+      "code": 6088,
+      "name": "LpSlippageToleranceExceeded",
+      "msg": "Lp slippage tolerance exceeded"
+    },
+    {
+      "code": 6089,
+      "name": "InvalidStartTime",
+      "msg": "Invalid start time. Loan start time must be within 5 minutes of current time"
+    },
+    {
+      "code": 6090,
+      "name": "InvalidWeightMatrix",
+      "msg": "Invalid weight matrix"
+    },
+    {
+      "code": 6091,
+      "name": "LoanPastEndTime",
+      "msg": "Loan is past end time"
+    },
+    {
+      "code": 6092,
+      "name": "InvalidCollateralWithdrawalWeightMatrixAssignment",
+      "msg": "Invalid collateral withdrawal weight matrix assignment"
+    },
+    {
+      "code": 6093,
+      "name": "TooMuchCollateralWithdrawn",
+      "msg": "Too much collateral withdrawn"
+    },
+    {
+      "code": 6094,
+      "name": "InvalidPrincipalWithdrawalWeightMatrixAssignment",
+      "msg": "Invalid principal withdrawal weight matrix assignment"
+    },
+    {
+      "code": 6095,
+      "name": "LedgerInRefinanceGracePeriodCannotBeWithdrawn",
+      "msg": "Ledger in refinance grace period cannot be withdrawn"
+    },
+    {
+      "code": 6096,
+      "name": "OnlyBorrowerCanRefinanceBeforeEnd",
+      "msg": "Only borrower can refinance before end"
+    },
+    {
+      "code": 6097,
+      "name": "InvalidDurationForLedgerSale",
+      "msg": "Invalid duration for ledger sale"
+    },
+    {
+      "code": 6098,
+      "name": "StakedSolCurrentlyUnsupported",
+      "msg": "Staked sol is currently unsupported"
+    },
+    {
+      "code": 6099,
+      "name": "LoanNotFullyRepaid",
+      "msg": "Loan has not been fully repaid"
+    },
+    {
+      "code": 6100,
+      "name": "InvalidLiquidationThreshold",
+      "msg": "Liquidation threshold must be >= ltv + buffer"
+    },
+    {
+      "code": 6101,
+      "name": "MaxAmountInExceeded",
+      "msg": "Max amount in exceeded"
+    },
+    {
+      "code": 6102,
+      "name": "MinAmountOutNotMet",
+      "msg": "Min amount out not met"
+    },
+    {
+      "code": 6103,
+      "name": "MissingAccount",
+      "msg": "Missing account"
+    },
+    {
+      "code": 6104,
+      "name": "LQTWeightedCollateralValueGreaterThanTotalDebt",
+      "msg": "LQT weighted collateral value is greater than total debt"
+    },
+    {
+      "code": 6105,
+      "name": "StrategyOriginationsDisabled",
+      "msg": "Strategy originations are disabled"
+    },
+    {
+      "code": 6106,
+      "name": "TimelockDelayNotMet",
+      "msg": "Timelock delay not met"
+    },
+    {
+      "code": 6107,
+      "name": "VaultDepositsDisabled",
+      "msg": "Vault deposits are disabled"
+    },
+    {
+      "code": 6108,
+      "name": "InvalidLpParams",
+      "msg": "Invalid LP params"
+    },
+    {
+      "code": 6109,
+      "name": "InvalidVaultAccount",
+      "msg": "Invalid Met Vault account"
+    },
+    {
+      "code": 6110,
+      "name": "InvalidCpiProgram",
+      "msg": "Invalid CPI program"
+    }
+  ],
+  "types": [
+    {
+      "name": "AddCollateralTimeLockArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "collateral_terms",
+            "type": {
+              "defined": {
+                "name": "CollateralTerms"
+              }
+            }
+          },
+          {
+            "name": "update_market_information_params",
+            "type": {
+              "defined": {
+                "name": "UpdateMarketInformationParams"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "AssetData",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "asset_identifier",
+            "type": "pubkey"
+          },
+          {
+            "name": "quote_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "oracle_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "oracle_type",
+            "type": "u8"
+          },
+          {
+            "name": "max_uncertainty",
+            "type": {
+              "defined": {
+                "name": "PodU32CBPS"
+              }
+            }
+          },
+          {
+            "name": "max_age",
+            "type": {
+              "defined": {
+                "name": "PodU16"
+              }
+            }
+          },
+          {
+            "name": "decimals",
+            "type": "u8"
+          },
+          {
+            "name": "ltv",
+            "type": {
+              "defined": {
+                "name": "PodU32CBPS"
+              }
+            }
+          },
+          {
+            "name": "liquidation_threshold",
+            "type": {
+              "defined": {
+                "name": "PodU32CBPS"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "BorrowPrincipalParams",
+      "docs": [
+        "Remaining accounts:\n\nnum ledgers = L\n\n 1. LTV Write:\n    0: Ledger[ledger_index] Market Information\n\n 2. Healthcheck:\n    For each ledger:\n    Ledger market information\n    Principal oracle accounts + conversion oracle accounts\n    Then for each collateral in the loan:\n    Collateral oracle accounts + conversion oracle accounts\n\nAsset index guidance:\n\n1. LTV write:\n   For ledger[ledger_index]:\n    Collateral index for each collateral\n2. Healthcheck:\n    For each ledger:\n        For each collateral in the loan:\n            Principal index\n            Collateral index"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "weight_matrix",
+            "type": {
+              "array": [
+                {
+                  "array": [
+                    "u32",
+                    5
+                  ]
+                },
+                5
+              ]
+            }
+          },
+          {
+            "name": "asset_index_guidance",
+            "type": {
+              "vec": "u64"
+            }
+          },
+          {
+            "name": "duration",
+            "type": "u8"
+          },
+          {
+            "name": "expected_loan_values",
+            "type": {
+              "defined": {
+                "name": "ExpectedLoanValues"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ClaimVaultFeeParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CloseLoopParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "ledger_index",
+            "type": "u8"
+          },
+          {
+            "name": "collateral_index",
+            "type": "u8"
+          },
+          {
+            "name": "swap_cpi_data",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "SwapCpiData"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "CollateralData",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "asset_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": {
+              "defined": {
+                "name": "PodU64"
+              }
+            }
+          },
+          {
+            "name": "asset_type",
+            "type": "u8"
+          },
+          {
+            "name": "asset_identifier",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CollateralTerms",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "asset_identifier",
+            "type": "pubkey"
+          },
+          {
+            "name": "terms",
+            "type": {
+              "array": [
+                "u64",
+                5
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "CollateralTermsIndices",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "collateral_index",
+            "type": "u64"
+          },
+          {
+            "name": "duration_index",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreateLoanParams",
+      "docs": [
+        "Remaining accounts:\n\n\n1. LTV Write:\n    0: Ledger Market Information\n\n2. Healthcheck:\n    Principal oracle accounts + conversion oracle accounts\n    Collateral oracle accounts + conversion oracle accounts\n\n\nAsset index guidance:\n1. LTV write:\n   For ledger[ledger_index]:\n    Collateral index for each collateral\n2. Healthcheck: -> don't need market information for healthcheck. Market information is already loaded in the accounts.\n    Principal index\n    Collateral index"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "principal_amount",
+            "type": "u64"
+          },
+          {
+            "name": "collateral_amount",
+            "type": "u64"
+          },
+          {
+            "name": "collateral_identifier",
+            "type": "pubkey"
+          },
+          {
+            "name": "collateral_type",
+            "type": "u8"
+          },
+          {
+            "name": "loan_type",
+            "type": "u8"
+          },
+          {
+            "name": "expected_apy",
+            "type": "u64"
+          },
+          {
+            "name": "expected_ltv",
+            "type": "u32"
+          },
+          {
+            "name": "expected_liquidation_threshold",
+            "type": "u32"
+          },
+          {
+            "name": "duration_index",
+            "type": "u8"
+          },
+          {
+            "name": "asset_index_guidance",
+            "type": {
+              "vec": "u64"
+            }
+          },
+          {
+            "name": "nonce",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreateMarketInformationParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "principal_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "authority",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreateStrategyParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lender",
+            "type": "pubkey"
+          },
+          {
+            "name": "origination_cap",
+            "type": "u64"
+          },
+          {
+            "name": "liquidity_buffer",
+            "type": "u64"
+          },
+          {
+            "name": "interest_fee",
+            "type": "u64"
+          },
+          {
+            "name": "origination_fee",
+            "type": "u64"
+          },
+          {
+            "name": "principal_fee",
+            "type": "u64"
+          },
+          {
+            "name": "originations_enabled",
+            "type": "bool"
+          },
+          {
+            "name": "external_yield_source_args",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "ExternalYieldSourceArgs"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreateVaultParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "token_name",
+            "type": "string"
+          },
+          {
+            "name": "token_symbol",
+            "type": "string"
+          },
+          {
+            "name": "token_uri",
+            "type": "string"
+          },
+          {
+            "name": "manager",
+            "type": "pubkey"
+          },
+          {
+            "name": "create_strategy_params",
+            "type": {
+              "defined": {
+                "name": "CreateStrategyParams"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "DepositCollateralParams",
+      "docs": [
+        "Remaining accounts:\n\nnum ledgers = L\n\n1. LTV Write:\n    0 -> (L-1): Ledger Market Information\n\nAsset index guidance:\n1. LTV Write:\n    0 -> (L-1): Collateral index for deposited collateral on the ledger market information"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "asset_type",
+            "type": "u8"
+          },
+          {
+            "name": "asset_identifier",
+            "type": "pubkey"
+          },
+          {
+            "name": "asset_index_guidance",
+            "type": {
+              "vec": "u64"
+            }
+          },
+          {
+            "name": "weight_matrix",
+            "type": {
+              "array": [
+                {
+                  "array": [
+                    "u32",
+                    5
+                  ]
+                },
+                5
+              ]
+            }
+          },
+          {
+            "name": "expected_loan_values",
+            "type": {
+              "defined": {
+                "name": "ExpectedLoanValues"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Duration",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "duration",
+            "type": {
+              "defined": {
+                "name": "PodU32"
+              }
+            }
+          },
+          {
+            "name": "duration_type",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ExactInParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount_in",
+            "type": "u64"
+          },
+          {
+            "name": "min_amount_out",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ExactOutParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount_out",
+            "type": "u64"
+          },
+          {
+            "name": "max_amount_in",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ExpectedLoanValues",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "expected_apy",
+            "type": "u64"
+          },
+          {
+            "name": "expected_ltv",
+            "type": {
+              "array": [
+                "u32",
+                5
+              ]
+            }
+          },
+          {
+            "name": "expected_liquidation_threshold",
+            "type": {
+              "array": [
+                "u32",
+                5
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ExternalYieldSourceArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "new_external_yield_source",
+            "type": "u8"
+          },
+          {
+            "name": "create_external_yield_account",
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Ledger",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "status",
+            "type": "u8"
+          },
+          {
+            "name": "strategy",
+            "type": "pubkey"
+          },
+          {
+            "name": "principal_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "market_information",
+            "type": "pubkey"
+          },
+          {
+            "name": "principal_due",
+            "type": {
+              "defined": {
+                "name": "PodU64"
+              }
+            }
+          },
+          {
+            "name": "principal_repaid",
+            "type": {
+              "defined": {
+                "name": "PodU64"
+              }
+            }
+          },
+          {
+            "name": "interest_due",
+            "type": {
+              "defined": {
+                "name": "PodU64"
+              }
+            }
+          },
+          {
+            "name": "interest_repaid",
+            "type": {
+              "defined": {
+                "name": "PodU64"
+              }
+            }
+          },
+          {
+            "name": "duration",
+            "type": {
+              "defined": {
+                "name": "Duration"
+              }
+            }
+          },
+          {
+            "name": "interest_per_second",
+            "type": {
+              "defined": {
+                "name": "PodDecimal"
+              }
+            }
+          },
+          {
+            "name": "start_time",
+            "type": {
+              "defined": {
+                "name": "PodU64"
+              }
+            }
+          },
+          {
+            "name": "end_time",
+            "type": {
+              "defined": {
+                "name": "PodU64"
+              }
+            }
+          },
+          {
+            "name": "apy",
+            "type": {
+              "defined": {
+                "name": "PodU64CBPS"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidateLedgerParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "ledger_index",
+            "type": "u8"
+          },
+          {
+            "name": "asset_index_guidance",
+            "type": {
+              "vec": "u64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Loan",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "version",
+            "type": "u8"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "loan_type",
+            "type": "u8"
+          },
+          {
+            "name": "borrower",
+            "type": "pubkey"
+          },
+          {
+            "name": "nonce",
+            "type": "u64"
+          },
+          {
+            "name": "start_time",
+            "type": {
+              "defined": {
+                "name": "PodU64"
+              }
+            }
+          },
+          {
+            "name": "ledgers",
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "Ledger"
+                  }
+                },
+                5
+              ]
+            }
+          },
+          {
+            "name": "collateral",
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "CollateralData"
+                  }
+                },
+                5
+              ]
+            }
+          },
+          {
+            "name": "weight_matrix",
+            "type": {
+              "array": [
+                {
+                  "array": [
+                    {
+                      "defined": {
+                        "name": "PodU32CBPS"
+                      }
+                    },
+                    5
+                  ]
+                },
+                5
+              ]
+            }
+          },
+          {
+            "name": "ltv_matrix",
+            "type": {
+              "array": [
+                {
+                  "array": [
+                    {
+                      "defined": {
+                        "name": "PodU32CBPS"
+                      }
+                    },
+                    5
+                  ]
+                },
+                5
+              ]
+            }
+          },
+          {
+            "name": "lqt_matrix",
+            "type": {
+              "array": [
+                {
+                  "array": [
+                    {
+                      "defined": {
+                        "name": "PodU32CBPS"
+                      }
+                    },
+                    5
+                  ]
+                },
+                5
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LpParams",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "ExactIn",
+            "fields": [
+              {
+                "defined": {
+                  "name": "ExactInParams"
+                }
+              }
+            ]
+          },
+          {
+            "name": "ExactOut",
+            "fields": [
+              {
+                "defined": {
+                  "name": "ExactOutParams"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "ManageOrcaLiquidityParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "liquidity_amount",
+            "type": "u128"
+          },
+          {
+            "name": "amount_a",
+            "type": "u64"
+          },
+          {
+            "name": "amount_b",
+            "type": "u64"
+          },
+          {
+            "name": "asset_index_guidance",
+            "type": {
+              "vec": "u64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MarketInformation",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "delegate",
+            "type": "pubkey"
+          },
+          {
+            "name": "principal_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "asset_data",
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "AssetData"
+                  }
+                },
+                200
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MultiCollateralTermsUpdateParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "apy",
+            "type": "u64"
+          },
+          {
+            "name": "indices",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "CollateralTermsIndices"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "OpenLoopParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "principal_amount",
+            "type": "u64"
+          },
+          {
+            "name": "collateral_amount",
+            "type": "u64"
+          },
+          {
+            "name": "expected_apy",
+            "type": "u64"
+          },
+          {
+            "name": "expected_ltv",
+            "type": "u32"
+          },
+          {
+            "name": "expected_liquidation_threshold",
+            "type": "u32"
+          },
+          {
+            "name": "deposit_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "deposit_amount",
+            "type": "u64"
+          },
+          {
+            "name": "duration_index",
+            "type": "u8"
+          },
+          {
+            "name": "asset_index_guidance",
+            "type": {
+              "vec": "u64"
+            }
+          },
+          {
+            "name": "nonce",
+            "type": "u64"
+          },
+          {
+            "name": "external_yield_end_index",
+            "type": "u8"
+          },
+          {
+            "name": "swap_cpi_data",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "SwapCpiData"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PodBool",
+      "docs": [
+        "Represents a bool stored as a byte"
+      ],
+      "repr": {
+        "kind": "transparent"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          "u8"
+        ]
+      }
+    },
+    {
+      "name": "PodDecimal",
+      "docs": [
+        "this is the scaled representation of a whole number. The whole number is scaled by 10^18 to avoid floating point errors when performing arithmetic operations."
+      ],
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "array": [
+              "u8",
+              24
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "PodU128",
+      "docs": [
+        "Represents a 128-bit unsigned integer stored as bytes (little-endian)"
+      ],
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "array": [
+              "u8",
+              16
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "PodU16",
+      "docs": [
+        "Represents a 16-bit unsigned integer stored as bytes (little-endian)"
+      ],
+      "repr": {
+        "kind": "transparent"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "array": [
+              "u8",
+              2
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "PodU32",
+      "docs": [
+        "Represents a 32-bit unsigned integer stored as bytes (little-endian)"
+      ],
+      "repr": {
+        "kind": "transparent"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "array": [
+              "u8",
+              4
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "PodU32CBPS",
+      "docs": [
+        "helper type to store u32 cbps values"
+      ],
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "array": [
+              "u8",
+              4
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "PodU64",
+      "docs": [
+        "Represents a 64-bit unsigned integer stored as bytes (little-endian)"
+      ],
+      "repr": {
+        "kind": "transparent"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "array": [
+              "u8",
+              8
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "PodU64CBPS",
+      "docs": [
+        "helper type to store u64 cbps values"
+      ],
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "array": [
+              "u8",
+              8
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "Position",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "whirlpool",
+            "type": "pubkey"
+          },
+          {
+            "name": "position_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "tick_lower_index",
+            "type": "i32"
+          },
+          {
+            "name": "tick_upper_index",
+            "type": "i32"
+          },
+          {
+            "name": "fee_growth_checkpoint_a",
+            "type": "u128"
+          },
+          {
+            "name": "fee_owed_a",
+            "type": "u64"
+          },
+          {
+            "name": "fee_growth_checkpoint_b",
+            "type": "u128"
+          },
+          {
+            "name": "fee_owed_b",
+            "type": "u64"
+          },
+          {
+            "name": "reward_infos",
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "PositionRewardInfo"
+                  }
+                },
+                3
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PositionRewardInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "growth_inside_checkpoint",
+            "type": "u128"
+          },
+          {
+            "name": "amount_owed",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RefinanceLedgerParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "ledger_index",
+            "type": "u8"
+          },
+          {
+            "name": "duration_index",
+            "type": "u8"
+          },
+          {
+            "name": "asset_index_guidance",
+            "type": {
+              "vec": "u64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "RepayPrincipalParams",
+      "docs": [
+        "No remaining accounts or asset index guidance needed. In full repayment, we zero out the matrix for the specific ledger using default loan values."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "ledger_index",
+            "type": "u8"
+          },
+          {
+            "name": "repay_all",
+            "type": "bool"
+          },
+          {
+            "name": "weight_matrix",
+            "type": {
+              "array": [
+                {
+                  "array": [
+                    "u32",
+                    5
+                  ]
+                },
+                5
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SellLedgerParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "ledger_index",
+            "type": "u8"
+          },
+          {
+            "name": "expected_sale_price",
+            "type": "u64"
+          },
+          {
+            "name": "buyer_duration_index",
+            "type": "u8"
+          },
+          {
+            "name": "asset_index_guidance",
+            "type": {
+              "vec": "u64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Strategy",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "version",
+            "type": "u8"
+          },
+          {
+            "name": "nonce",
+            "type": "pubkey"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "principal_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "lender",
+            "type": "pubkey"
+          },
+          {
+            "name": "originations_enabled",
+            "type": {
+              "defined": {
+                "name": "PodBool"
+              }
+            }
+          },
+          {
+            "name": "external_yield_source",
+            "type": "u8"
+          },
+          {
+            "name": "interest_per_second",
+            "type": {
+              "defined": {
+                "name": "PodDecimal"
+              }
+            }
+          },
+          {
+            "name": "last_accrued_timestamp",
+            "docs": [
+              "timestamp interest per second's interest was last accrued"
+            ],
+            "type": {
+              "defined": {
+                "name": "PodU64"
+              }
+            }
+          },
+          {
+            "name": "liquidity_buffer",
+            "docs": [
+              "the is the amount of liquidity % that always needs to be in the strategy"
+            ],
+            "type": {
+              "defined": {
+                "name": "PodU64CBPS"
+              }
+            }
+          },
+          {
+            "name": "token_balance",
+            "docs": [
+              "amount of principal in the strategy"
+            ],
+            "type": {
+              "defined": {
+                "name": "PodU64"
+              }
+            }
+          },
+          {
+            "name": "interest_fee",
+            "docs": [
+              "this is the fee charged by and accrued to the manager on the interest accrued via external yield and loans"
+            ],
+            "type": {
+              "defined": {
+                "name": "PodU64CBPS"
+              }
+            }
+          },
+          {
+            "name": "principal_fee",
+            "docs": [
+              "this is the fee charged by and accrued to the manager on the origination fee"
+            ],
+            "type": {
+              "defined": {
+                "name": "PodU64CBPS"
+              }
+            }
+          },
+          {
+            "name": "origination_fee",
+            "docs": [
+              "fee charged on origination of new loans"
+            ],
+            "type": {
+              "defined": {
+                "name": "PodU64CBPS"
+              }
+            }
+          },
+          {
+            "name": "origination_cap",
+            "docs": [
+              "the maximum size of a loan that can be originated"
+            ],
+            "type": {
+              "defined": {
+                "name": "PodU64"
+              }
+            }
+          },
+          {
+            "name": "external_yield_amount",
+            "docs": [
+              "this is the amount of principal currently in external yield. has to always be updated on any new nav action"
+            ],
+            "type": {
+              "defined": {
+                "name": "PodU64"
+              }
+            }
+          },
+          {
+            "name": "current_deployed_amount",
+            "docs": [
+              "this is the amount of principal currently deployed in loans"
+            ],
+            "type": {
+              "defined": {
+                "name": "PodU64"
+              }
+            }
+          },
+          {
+            "name": "outstanding_interest_amount",
+            "docs": [
+              "this is the interest that has not been repaid yet but accrued"
+            ],
+            "type": {
+              "defined": {
+                "name": "PodU64"
+              }
+            }
+          },
+          {
+            "name": "fee_claimable",
+            "docs": [
+              "this is the amount that has accrued to the manager"
+            ],
+            "type": {
+              "defined": {
+                "name": "PodU64"
+              }
+            }
+          },
+          {
+            "name": "cumulative_principal_originated",
+            "type": {
+              "defined": {
+                "name": "PodU128"
+              }
+            }
+          },
+          {
+            "name": "cumulative_interest_accrued",
+            "type": {
+              "defined": {
+                "name": "PodU128"
+              }
+            }
+          },
+          {
+            "name": "cumulative_loan_count",
+            "type": {
+              "defined": {
+                "name": "PodU64"
+              }
+            }
+          },
+          {
+            "name": "active_loan_count",
+            "type": {
+              "defined": {
+                "name": "PodU64"
+              }
+            }
+          },
+          {
+            "name": "market_information",
+            "type": "pubkey"
+          },
+          {
+            "name": "collateral_map",
+            "type": {
+              "array": [
+                {
+                  "array": [
+                    {
+                      "defined": {
+                        "name": "PodU64"
+                      }
+                    },
+                    5
+                  ]
+                },
+                200
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SwapCpiData",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "num_swap_remaining_accounts",
+            "type": "u8"
+          },
+          {
+            "name": "cpi_data",
+            "type": "bytes"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Timelock",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "init_timestamp",
+            "type": "i64"
+          },
+          {
+            "name": "execution_delay",
+            "type": "i64"
+          },
+          {
+            "name": "params",
+            "type": {
+              "defined": {
+                "name": "TimelockUpdateParams"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "TimelockCanceledEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "timelock",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TimelockCreatedEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "timelock_address",
+            "type": "string"
+          },
+          {
+            "name": "vault_address",
+            "type": "string"
+          },
+          {
+            "name": "timelock_params",
+            "type": {
+              "defined": {
+                "name": "TimelockUpdateParams"
+              }
+            }
+          },
+          {
+            "name": "timelock_init_timestamp",
+            "type": "i64"
+          },
+          {
+            "name": "timelock_execution_delay",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TimelockExecutedEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "timelock",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TimelockUpdateParams",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "UpdateMarketInformation",
+            "fields": [
+              "pubkey"
+            ]
+          },
+          {
+            "name": "AddCollateral",
+            "fields": [
+              {
+                "defined": {
+                  "name": "AddCollateralTimeLockArgs"
+                }
+              }
+            ]
+          },
+          {
+            "name": "UpdateLtv",
+            "fields": [
+              {
+                "defined": {
+                  "name": "UpdateMarketInformationParams"
+                }
+              }
+            ]
+          },
+          {
+            "name": "RemoveCollateral",
+            "fields": [
+              {
+                "defined": {
+                  "name": "CollateralTerms"
+                }
+              }
+            ]
+          },
+          {
+            "name": "UpdateApy",
+            "fields": [
+              {
+                "defined": {
+                  "name": "CollateralTerms"
+                }
+              }
+            ]
+          },
+          {
+            "name": "UpdateStrategy",
+            "fields": [
+              {
+                "defined": {
+                  "name": "UpdateStrategyParams"
+                }
+              }
+            ]
+          },
+          {
+            "name": "UpdateVault",
+            "fields": [
+              "u64"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "TransferOrcaPositionParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "liquidity_amount",
+            "type": "u128"
+          },
+          {
+            "name": "token_max_a",
+            "type": "u64"
+          },
+          {
+            "name": "token_max_b",
+            "type": "u64"
+          },
+          {
+            "name": "tick_lower_index",
+            "type": "i32"
+          },
+          {
+            "name": "tick_upper_index",
+            "type": "i32"
+          },
+          {
+            "name": "asset_index_guidance",
+            "type": {
+              "vec": "u64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateMarketInformationParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "asset_identifier",
+            "type": "pubkey"
+          },
+          {
+            "name": "quote_mint",
+            "type": {
+              "option": "pubkey"
+            }
+          },
+          {
+            "name": "oracle_account",
+            "type": {
+              "option": "pubkey"
+            }
+          },
+          {
+            "name": "oracle_type",
+            "type": {
+              "option": "u8"
+            }
+          },
+          {
+            "name": "max_uncertainty",
+            "type": {
+              "option": "u32"
+            }
+          },
+          {
+            "name": "max_age",
+            "type": {
+              "option": "u16"
+            }
+          },
+          {
+            "name": "decimals",
+            "type": {
+              "option": "u8"
+            }
+          },
+          {
+            "name": "ltv",
+            "type": {
+              "option": "u32"
+            }
+          },
+          {
+            "name": "liquidation_threshold",
+            "type": {
+              "option": "u32"
+            }
+          },
+          {
+            "name": "remove",
+            "type": {
+              "option": "bool"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateStrategyParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "originations_enabled",
+            "type": {
+              "option": "bool"
+            }
+          },
+          {
+            "name": "liquidity_buffer",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "interest_fee",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "origination_fee",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "principal_fee",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "origination_cap",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "market_information",
+            "type": {
+              "option": "pubkey"
+            }
+          },
+          {
+            "name": "external_yield_source_args",
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "ExternalYieldSourceArgs"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateVaultParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "deposits_enabled",
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Vault",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "manager",
+            "type": "pubkey"
+          },
+          {
+            "name": "nonce",
+            "type": "pubkey"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "lp_supply",
+            "type": {
+              "defined": {
+                "name": "PodU64"
+              }
+            }
+          },
+          {
+            "name": "lp_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "principal_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "cumulative_principal_deposited",
+            "type": {
+              "defined": {
+                "name": "PodU64"
+              }
+            }
+          },
+          {
+            "name": "deposits_enabled",
+            "type": {
+              "defined": {
+                "name": "PodBool"
+              }
+            }
+          },
+          {
+            "name": "max_early_unstake_fee",
+            "type": {
+              "defined": {
+                "name": "PodU64CBPS"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "VaultStake",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "nonce",
+            "type": "pubkey"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "user",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": {
+              "defined": {
+                "name": "PodU64"
+              }
+            }
+          },
+          {
+            "name": "duration",
+            "type": {
+              "defined": {
+                "name": "Duration"
+              }
+            }
+          },
+          {
+            "name": "start_time",
+            "type": {
+              "defined": {
+                "name": "PodU64"
+              }
+            }
+          },
+          {
+            "name": "end_time",
+            "type": {
+              "defined": {
+                "name": "PodU64"
+              }
+            }
+          },
+          {
+            "name": "unstake_time",
+            "type": {
+              "defined": {
+                "name": "PodU64"
+              }
+            }
+          },
+          {
+            "name": "unstake_fee_applied",
+            "type": {
+              "defined": {
+                "name": "PodU64"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "VaultStakeParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "stake_all",
+            "type": {
+              "option": "bool"
+            }
+          },
+          {
+            "name": "duration",
+            "type": "u32"
+          },
+          {
+            "name": "duration_type",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Whirlpool",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "whirlpools_config",
+            "type": "pubkey"
+          },
+          {
+            "name": "whirlpool_bump",
+            "type": {
+              "array": [
+                "u8",
+                1
+              ]
+            }
+          },
+          {
+            "name": "tick_spacing",
+            "type": "u16"
+          },
+          {
+            "name": "tick_spacing_seed",
+            "type": {
+              "array": [
+                "u8",
+                2
+              ]
+            }
+          },
+          {
+            "name": "fee_rate",
+            "type": "u16"
+          },
+          {
+            "name": "protocol_fee_rate",
+            "type": "u16"
+          },
+          {
+            "name": "liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "sqrt_price",
+            "type": "u128"
+          },
+          {
+            "name": "tick_current_index",
+            "type": "i32"
+          },
+          {
+            "name": "protocol_fee_owed_a",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_fee_owed_b",
+            "type": "u64"
+          },
+          {
+            "name": "token_mint_a",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_vault_a",
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_growth_global_a",
+            "type": "u128"
+          },
+          {
+            "name": "token_mint_b",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_vault_b",
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_growth_global_b",
+            "type": "u128"
+          },
+          {
+            "name": "reward_last_updated_timestamp",
+            "type": "u64"
+          },
+          {
+            "name": "reward_infos",
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "WhirlpoolRewardInfo"
+                  }
+                },
+                3
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "WhirlpoolRewardInfo",
+      "docs": [
+        "Stores the state relevant for tracking liquidity mining rewards at the `Whirlpool` level.",
+        "These values are used in conjunction with `PositionRewardInfo`, `Tick.reward_growths_outside`,",
+        "and `Whirlpool.reward_last_updated_timestamp` to determine how many rewards are earned by open",
+        "positions."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mint",
+            "docs": [
+              "Reward token mint."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "vault",
+            "docs": [
+              "Reward vault token account."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "authority",
+            "docs": [
+              "Authority account that has permission to initialize the reward and set emissions."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "emissions_per_second_x64",
+            "docs": [
+              "Q64.64 number that indicates how many tokens per second are earned per unit of liquidity."
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "growth_global_x64",
+            "docs": [
+              "Q64.64 number that tracks the total tokens earned per unit of liquidity since the reward",
+              "emissions were turned on."
+            ],
+            "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "WithdrawCollateralParams",
+      "docs": [
+        "Remaining accounts:\n\nnum ledgers = L\n\n1. 0 -> 2L-1: Strategy + MarketInformation for ledger L_i\n\n2. Healthcheck:\n    For each ledger:\n    Ledger market information\n    Principal oracle accounts + conversion oracle accounts\n    Then again for each ledger and collateral:\n        Collateral oracle accounts + conversion oracle accounts\n\n\nAsset index guidance:\n1. Healthcheck:\n    For each ledger:\n        For each collateral in the loan:\n            Principal index\n            Collateral index"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "collateral_index",
+            "type": "u8"
+          },
+          {
+            "name": "weight_matrix",
+            "type": {
+              "array": [
+                {
+                  "array": [
+                    "u32",
+                    5
+                  ]
+                },
+                5
+              ]
+            }
+          },
+          {
+            "name": "asset_index_guidance",
+            "type": {
+              "vec": "u64"
+            }
+          },
+          {
+            "name": "expected_loan_values",
+            "type": {
+              "defined": {
+                "name": "ExpectedLoanValues"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/programs/invest-in-sol/src/instructions/cpi/loopscale/mod.rs
+++ b/programs/invest-in-sol/src/instructions/cpi/loopscale/mod.rs
@@ -1,0 +1,12 @@
+// unsure if this is needed
+
+
+
+// pub mod types;
+// pub mod cpi;
+
+// pub use types::*;
+// pub use cpi::*;
+
+// use anchor_lang::prelude::*;
+// declare_id!("1oopBoJG58DgkUVKkEzKgyG9dvRmpgeEm1AVjoHkF78"); 

--- a/programs/invest-in-sol/src/instructions/cpi/loopscale/types/accounts.rs
+++ b/programs/invest-in-sol/src/instructions/cpi/loopscale/types/accounts.rs
@@ -1,0 +1,165 @@
+use anchor_lang::prelude::*;
+use anchor_lang::{AnchorDeserialize, AnchorSerialize};
+use bytemuck::{Pod, Zeroable};
+
+use super::pod::*;
+
+#[repr(C)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Zeroable, Pod, Debug, PartialEq)]
+pub struct Duration {
+    pub duration: PodU32,
+    pub duration_type: u8,
+}
+
+#[repr(C)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Zeroable, Pod, Debug, PartialEq)]
+pub struct AssetData {
+    pub asset_identifier: Pubkey,
+    pub quote_mint: Pubkey,
+    pub oracle_account: Pubkey,
+    pub oracle_type: u8,
+    pub max_uncertainty: PodU32CBPS,
+    pub max_age: PodU16,
+    pub decimals: u8,
+    pub ltv: PodU32CBPS,
+    pub liquidation_threshold: PodU32CBPS,
+}
+
+#[repr(C)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Zeroable, Pod, Debug, PartialEq)]
+pub struct CollateralData {
+    pub asset_mint: Pubkey,
+    pub amount: PodU64,
+    pub asset_type: u8,
+    pub asset_identifier: Pubkey,
+}
+
+#[repr(C)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Zeroable, Pod, Debug, PartialEq)]
+pub struct Ledger {
+    pub status: u8,
+    pub strategy: Pubkey,
+    pub principal_mint: Pubkey,
+    pub market_information: Pubkey,
+    pub principal_due: PodU64,
+    pub principal_repaid: PodU64,
+    pub interest_due: PodU64,
+    pub interest_repaid: PodU64,
+    pub duration: Duration,
+    pub interest_per_second: PodDecimal,
+    pub start_time: PodU64,
+    pub end_time: PodU64,
+    pub apy: PodU64CBPS,
+}
+
+#[repr(C)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Zeroable, Pod, Debug, PartialEq)]
+pub struct Loan {
+    pub version: u8,
+    pub bump: u8,
+    pub loan_type: u8,
+    pub borrower: Pubkey,
+    pub nonce: u64,
+    pub start_time: PodU64,
+    pub ledgers: [Ledger; 5],
+    pub collateral: [CollateralData; 5],
+    pub weight_matrix: [[PodU32CBPS; 5]; 5],
+    pub ltv_matrix: [[PodU32CBPS; 5]; 5],
+    pub lqt_matrix: [[PodU32CBPS; 5]; 5],
+}
+
+#[repr(C)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Zeroable, Pod, Debug, PartialEq)]
+pub struct Strategy {
+    pub version: u8,
+    pub nonce: Pubkey,
+    pub bump: u8,
+    pub principal_mint: Pubkey,
+    pub lender: Pubkey,
+    pub originations_enabled: PodBool,
+    pub external_yield_source: u8,
+    pub interest_per_second: PodDecimal,
+    pub last_accrued_timestamp: PodU64,
+    pub liquidity_buffer: PodU64CBPS,
+    pub token_balance: PodU64,
+    pub interest_fee: PodU64CBPS,
+    pub principal_fee: PodU64CBPS,
+    pub origination_fee: PodU64CBPS,
+    pub origination_cap: PodU64,
+    pub external_yield_amount: PodU64,
+    pub current_deployed_amount: PodU64,
+    pub outstanding_interest_amount: PodU64,
+    pub fee_claimable: PodU64,
+    pub cumulative_principal_originated: PodU128,
+    pub cumulative_interest_accrued: PodU128,
+    pub cumulative_loan_count: PodU64,
+    pub active_loan_count: PodU64,
+    pub market_information: Pubkey,
+    pub collateral_map: [[PodU64; 5]; 200],
+}
+
+#[repr(C)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Zeroable, Pod, Debug, PartialEq)]
+pub struct MarketInformation {
+    pub authority: Pubkey,
+    pub delegate: Pubkey,
+    pub principal_mint: Pubkey,
+    pub asset_data: [AssetData; 200],
+}
+
+#[repr(C)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Zeroable, Pod, Debug, PartialEq)]
+pub struct Vault {
+    pub manager: Pubkey,
+    pub nonce: Pubkey,
+    pub bump: u8,
+    pub lp_supply: PodU64,
+    pub lp_mint: Pubkey,
+    pub principal_mint: Pubkey,
+    pub cumulative_principal_deposited: PodU64,
+    pub deposits_enabled: PodBool,
+    pub max_early_unstake_fee: PodU64CBPS,
+}
+
+#[repr(C)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Zeroable, Pod, Debug, PartialEq)]
+pub struct VaultStake {
+    pub vault: Pubkey,
+    pub nonce: Pubkey,
+    pub bump: u8,
+    pub user: Pubkey,
+    pub amount: PodU64,
+    pub duration: Duration,
+    pub start_time: PodU64,
+    pub end_time: PodU64,
+    pub unstake_time: PodU64,
+    pub unstake_fee_applied: PodU64,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct PositionRewardInfo {
+    pub growth_inside_checkpoint: u128,
+    pub amount_owed: u64,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct Position {
+    pub whirlpool: Pubkey,
+    pub position_mint: Pubkey,
+    pub liquidity: u128,
+    pub tick_lower_index: i32,
+    pub tick_upper_index: i32,
+    pub fee_growth_checkpoint_a: u128,
+    pub fee_owed_a: u64,
+    pub fee_growth_checkpoint_b: u128,
+    pub fee_owed_b: u64,
+    pub reward_infos: [PositionRewardInfo; 3],
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct Timelock {
+    pub vault: Pubkey,
+    pub init_timestamp: i64,
+    pub execution_delay: i64,
+    pub params: super::instructions::TimelockUpdateParams,
+} 

--- a/programs/invest-in-sol/src/instructions/cpi/loopscale/types/errors.rs
+++ b/programs/invest-in-sol/src/instructions/cpi/loopscale/types/errors.rs
@@ -1,0 +1,337 @@
+use anchor_lang::prelude::*;
+
+#[error_code]
+pub enum LoopscaleError {
+    #[msg("The collateral mint specified does not match identifier according to type")]
+    InvalidCollateralMintOrIdentifier,
+
+    #[msg("Loan doesnt have enough collateral for maintenance")]
+    MaintanenceCollateralNotMet,
+
+    #[msg("Arithmetic overflow")]
+    ArithmeticOverflow,
+
+    #[msg("Invalid timestamp")]
+    InvalidTimestamp,
+
+    #[msg("Max Collateral reached")]
+    MaxCollateralReached,
+
+    #[msg("Partial withdraws not allowed for orca positions")]
+    PartialWithdrawsNotAllowedForOrcaPositions,
+
+    #[msg("Invalid ledger status for refinance")]
+    InvalidLedgerStatusForRefinance,
+
+    #[msg("Invalid ledger status for ledger sale")]
+    InvalidLedgerStatusForLedgerSale,
+
+    #[msg("Invalid market information")]
+    InvalidMarketInformation,
+
+    #[msg("Loan size exceeds max origination size")]
+    LoanSizeExceedsMaxOriginationSize,
+
+    #[msg("Invalid manager")]
+    InvalidManager,
+
+    #[msg("No open ledgers")]
+    NoOpenLedgers,
+
+    #[msg("Invalid duration index")]
+    InvalidDurationIndex,
+
+    #[msg("Invalid asset identifier")]
+    InvalidAssetIdentifier,
+
+    #[msg("APY is disabled")]
+    APYDisabled,
+
+    #[msg("Collateral not present")]
+    CollateralNotPresent,
+
+    #[msg("Invalid principal mint")]
+    InvalidPrincipalMint,
+
+    #[msg("Invalid ledger strategy")]
+    InvalidLedgerStrategy,
+
+    #[msg("Invalid ledger index")]
+    InvalidLedgerIndex,
+
+    #[msg("No supported collateral found")]
+    NoSupportedCollateralFound,
+
+    #[msg("Cannot sell to same strategy")]
+    CannotSellToSameStrategy,
+
+    #[msg("Invalid Oracle account")]
+    InvalidOracleAccount,
+
+    #[msg("Invalid Legacy Pyth account")]
+    InvalidLegacyPythAccount,
+
+    #[msg("Invalid price exponent")]
+    InvalidPriceExpo,
+
+    #[msg("Stale Pyth price")]
+    StalePythPrice,
+
+    #[msg("Price uncertainilty is more than max uncertainity")]
+    PriceUncertainityExceeded,
+
+    #[msg("Price cannot be negative")]
+    NegativePrice,
+
+    #[msg("Price overflow")]
+    PriceOverflow,
+
+    #[msg("Missing Oracle Information account in remaining accounts")]
+    MissingMarketInformationAccount,
+
+    #[msg("Missing Oracle account in remaining accounts")]
+    MissingOracleAccount,
+
+    #[msg("Invalid seeds provided")]
+    InvalidSeeds,
+
+    #[msg("Invalid loan vault")]
+    InvalidLoanVault,
+
+    #[msg("Loan not in default")]
+    LoanNotInDefault,
+
+    #[msg("Order status must be filled")]
+    OrderStatusMismatch,
+
+    #[msg("LST Oracle invalid")]
+    LSTOracleInvalid,
+
+    #[msg("Could not get price per LST")]
+    LSTOraclePriceNotFound,
+
+    #[msg("Stale LST price")]
+    StaleLSTPrice,
+
+    #[msg("value could not be converted to Decimal")]
+    InvalidDecimal,
+
+    #[msg("Invalid quote mint for conversion oracle")]
+    InvalidConversionOracleQuote,
+
+    #[msg("Missing conversion rate")]
+    MissingConversionRate,
+
+    #[msg("Not enough remaining accounts passed in. Each lockbox asset requires at least 2 remaining accounts")]
+    NotEnoughRemainingAccounts,
+
+    #[msg("Invalid quote mint for vault oracle. Must be the same as vault base token")]
+    InvalidQuoteMintForMeteoraVault,
+
+    #[msg("Invalid base mint for vault oracle. Must be the same as vault LP token")]
+    InvalidBaseMintForMeteoraVault,
+
+    #[msg("Invalid decimals for vault oracle. Must be the same as vault LP token")]
+    InvalidDecimalsForMeteoraVault,
+
+    #[msg("Could not calculate total amount for meteroa vault")]
+    MeteoraVaultTotalAmountErr,
+
+    #[msg("Not enough extra accounts")]
+    InvalidExtraAccounts,
+
+    #[msg("Invalid switchboard account owner")]
+    InvalidSwitchboardAccountOwner,
+
+    #[msg("Invalid switchboard account")]
+    InvalidSwitchboardAccount,
+
+    #[msg("Invalid orca account owner")]
+    InvalidOrcaAccountOwner,
+
+    #[msg("Invalid orca position")]
+    InvalidOrcaPosition,
+
+    #[msg("Invalid orca whirlpool")]
+    InvalidOrcaWhirlpool,
+
+    #[msg("Invalid orca tick array")]
+    InvalidOrcaTickArray,
+
+    #[msg("Position does not match whirlpool")]
+    PositionDoesNotMatchWhirlpool,
+
+    #[msg("Position does not match mint")]
+    PositionDoesNotMatchMint,
+
+    #[msg("Tick array does not match whirlpool")]
+    TickArrayDoesNotMatchWhirlpool,
+
+    #[msg("Mint does not match whirlpool")]
+    MintDoesNotMatchWhirlpool,
+
+    #[msg("Invalid Pyth account")]
+    InvalidPythAccount,
+
+    #[msg("Invalid LTV data")]
+    InvalidLtvData,
+
+    #[msg("Ltv data not found")]
+    LtvDataNotFound,
+
+    #[msg("Invalid mint type for oracle")]
+    InvalidMintType,
+
+    #[msg("Invalid meteora pool")]
+    InvalidMeteoraPool,
+
+    #[msg("Invalid LP account")]
+    InvalidLPAccount,
+
+    #[msg("Unsupported curve type")]
+    UnsupportedCurveType,
+
+    #[msg("Swap simulation failed")]
+    SwapSimulationFailed,
+
+    #[msg("Invalid base mint for FLP")]
+    InvalidBaseMintForFLP,
+
+    #[msg("FLP pool not supported")]
+    FLPPoolNotSupported,
+
+    #[msg("Invalid asset index")]
+    InvalidAssetIndex,
+
+    #[msg("Invalid asset index guidance")]
+    InvalidAssetIndexGuidance,
+
+    #[msg("Quote price not found in cache")]
+    PriceNotFound,
+
+    #[msg("Duplicate collateral mints in market information")]
+    DuplicateCollateralMintsInMarketInformation,
+
+    #[msg("Market information is full")]
+    MarketInformationFull,
+
+    #[msg("Asset not found in market information")]
+    AssetNotFoundInMarketInformation,
+
+    #[msg("Market information already exists")]
+    MarketInformationAlreadyExists,
+
+    #[msg("Invalid vault strategy")]
+    InvalidVaultStrategy,
+
+    #[msg("Cannot liquidate a healthy ledger")]
+    LedgerHealthy,
+
+    #[msg("Invalid liquidation")]
+    InvalidLiquidation,
+
+    #[msg("Liquidity buffer has been exceeded")]
+    InsufficientLiquidity,
+
+    #[msg("Interest not accrued")]
+    InterestNotAccrued,
+
+    #[msg("Invalid interest per second. Must be 0")]
+    InvalidInterestPerSecondForClose,
+
+    #[msg("Invalid external yield amount. Must be 0")]
+    InvalidExternalYieldAmountForClose,
+
+    #[msg("Invalid current deployed amount. Must be 0")]
+    InvalidCurrentDeployedAmountForClose,
+
+    #[msg("Invalid token balance. Must be 0")]
+    InvalidTokenBalanceForClose,
+
+    #[msg("Invalid fee claimable. Must be 0")]
+    InvalidFeeClaimableForClose,
+
+    #[msg("Invalid lender")]
+    InvalidLender,
+
+    #[msg("Sale slippage exceeded")]
+    SaleSlippageExceeded,
+
+    #[msg("Expected LTV mismatch")]
+    ExpectedLtvMismatch,
+
+    #[msg("Expected LQT mismatch")]
+    ExpectedLqtMismatch,
+
+    #[msg("Expected APY mismatch")]
+    ExpectedApyMismatch,
+
+    #[msg("Lp slippage tolerance exceeded")]
+    LpSlippageToleranceExceeded,
+
+    #[msg("Invalid start time. Loan start time must be within 5 minutes of current time")]
+    InvalidStartTime,
+
+    #[msg("Invalid weight matrix")]
+    InvalidWeightMatrix,
+
+    #[msg("Loan is past end time")]
+    LoanPastEndTime,
+
+    #[msg("Invalid collateral withdrawal weight matrix assignment")]
+    InvalidCollateralWithdrawalWeightMatrixAssignment,
+
+    #[msg("Too much collateral withdrawn")]
+    TooMuchCollateralWithdrawn,
+
+    #[msg("Invalid principal withdrawal weight matrix assignment")]
+    InvalidPrincipalWithdrawalWeightMatrixAssignment,
+
+    #[msg("Ledger in refinance grace period cannot be withdrawn")]
+    LedgerInRefinanceGracePeriodCannotBeWithdrawn,
+
+    #[msg("Only borrower can refinance before end")]
+    OnlyBorrowerCanRefinanceBeforeEnd,
+
+    #[msg("Invalid duration for ledger sale")]
+    InvalidDurationForLedgerSale,
+
+    #[msg("Staked sol is currently unsupported")]
+    StakedSolCurrentlyUnsupported,
+
+    #[msg("Loan has not been fully repaid")]
+    LoanNotFullyRepaid,
+
+    #[msg("Liquidation threshold must be >= ltv + buffer")]
+    InvalidLiquidationThreshold,
+
+    #[msg("Max amount in exceeded")]
+    MaxAmountInExceeded,
+
+    #[msg("Min amount out not met")]
+    MinAmountOutNotMet,
+
+    #[msg("Missing account")]
+    MissingAccount,
+
+    #[msg("LQT weighted collateral value is greater than total debt")]
+    LQTWeightedCollateralValueGreaterThanTotalDebt,
+
+    #[msg("Strategy originations are disabled")]
+    StrategyOriginationsDisabled,
+
+    #[msg("Timelock delay not met")]
+    TimelockDelayNotMet,
+
+    #[msg("Vault deposits are disabled")]
+    VaultDepositsDisabled,
+
+    #[msg("Invalid LP params")]
+    InvalidLpParams,
+
+    #[msg("Invalid Met Vault account")]
+    InvalidVaultAccount,
+
+    #[msg("Invalid CPI program")]
+    InvalidCpiProgram,
+} 

--- a/programs/invest-in-sol/src/instructions/cpi/loopscale/types/instructions.rs
+++ b/programs/invest-in-sol/src/instructions/cpi/loopscale/types/instructions.rs
@@ -1,0 +1,253 @@
+use anchor_lang::prelude::*;
+use super::pod::*;
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct CollateralTerms {
+    pub asset_identifier: Pubkey,
+    pub terms: [u64; 5],
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct UpdateMarketInformationParams {
+    pub asset_identifier: Pubkey,
+    pub quote_mint: Option<Pubkey>,
+    pub oracle_account: Option<Pubkey>,
+    pub oracle_type: Option<u8>,
+    pub max_uncertainty: Option<u32>,
+    pub max_age: Option<u16>,
+    pub decimals: Option<u8>,
+    pub ltv: Option<u32>,
+    pub liquidation_threshold: Option<u32>,
+    pub remove: Option<bool>,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct AddCollateralTimeLockArgs {
+    pub collateral_terms: CollateralTerms,
+    pub update_market_information_params: UpdateMarketInformationParams,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct ExpectedLoanValues {
+    pub expected_apy: u64,
+    pub expected_ltv: [u32; 5],
+    pub expected_liquidation_threshold: [u32; 5],
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct BorrowPrincipalParams {
+    pub amount: u64,
+    pub weight_matrix: [[u32; 5]; 5],
+    pub asset_index_guidance: Vec<u64>,
+    pub duration: u8,
+    pub expected_loan_values: ExpectedLoanValues,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct ClaimVaultFeeParams {
+    pub amount: u64,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct SwapCpiData {
+    pub num_swap_remaining_accounts: u8,
+    #[serde(with = "serde_bytes")]
+    pub cpi_data: Vec<u8>,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct CloseLoopParams {
+    pub ledger_index: u8,
+    pub collateral_index: u8,
+    pub swap_cpi_data: Vec<SwapCpiData>,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct CreateLoanParams {
+    pub principal_amount: u64,
+    pub collateral_amount: u64,
+    pub collateral_identifier: Pubkey,
+    pub collateral_type: u8,
+    pub loan_type: u8,
+    pub expected_apy: u64,
+    pub expected_ltv: u32,
+    pub expected_liquidation_threshold: u32,
+    pub duration_index: u8,
+    pub asset_index_guidance: Vec<u64>,
+    pub nonce: u64,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct CreateMarketInformationParams {
+    pub principal_mint: Pubkey,
+    pub authority: Pubkey,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct ExternalYieldSourceArgs {
+    pub new_external_yield_source: u8,
+    pub create_external_yield_account: bool,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct CreateStrategyParams {
+    pub lender: Pubkey,
+    pub origination_cap: u64,
+    pub liquidity_buffer: u64,
+    pub interest_fee: u64,
+    pub origination_fee: u64,
+    pub principal_fee: u64,
+    pub originations_enabled: bool,
+    pub external_yield_source_args: Option<ExternalYieldSourceArgs>,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct CreateVaultParams {
+    pub token_name: String,
+    pub token_symbol: String,
+    pub token_uri: String,
+    pub manager: Pubkey,
+    pub create_strategy_params: CreateStrategyParams,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct DepositCollateralParams {
+    pub amount: u64,
+    pub asset_type: u8,
+    pub asset_identifier: Pubkey,
+    pub asset_index_guidance: Vec<u64>,
+    pub weight_matrix: [[u32; 5]; 5],
+    pub expected_loan_values: ExpectedLoanValues,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct ExactInParams {
+    pub amount_in: u64,
+    pub min_amount_out: u64,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct ExactOutParams {
+    pub amount_out: u64,
+    pub max_amount_in: u64,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub enum LpParams {
+    ExactIn(ExactInParams),
+    ExactOut(ExactOutParams),
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct ManageOrcaLiquidityParams {
+    pub liquidity_amount: u128,
+    pub amount_a: u64,
+    pub amount_b: u64,
+    pub asset_index_guidance: Vec<u64>,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct MultiCollateralTermsUpdateParams {
+    pub apy: u64,
+    pub indices: Vec<CollateralTermsIndices>,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct CollateralTermsIndices {
+    pub collateral_index: u64,
+    pub duration_index: u8,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct OpenLoopParams {
+    pub principal_amount: u64,
+    pub collateral_amount: u64,
+    pub expected_apy: u64,
+    pub expected_ltv: u32,
+    pub expected_liquidation_threshold: u32,
+    pub deposit_mint: Pubkey,
+    pub deposit_amount: u64,
+    pub duration_index: u8,
+    pub asset_index_guidance: Vec<u64>,
+    pub nonce: u64,
+    pub external_yield_end_index: u8,
+    pub swap_cpi_data: Vec<SwapCpiData>,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct RefinanceLedgerParams {
+    pub ledger_index: u8,
+    pub duration_index: u8,
+    pub asset_index_guidance: Vec<u64>,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct RepayPrincipalParams {
+    pub amount: u64,
+    pub ledger_index: u8,
+    pub repay_all: bool,
+    pub weight_matrix: [[u32; 5]; 5],
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct SellLedgerParams {
+    pub ledger_index: u8,
+    pub expected_sale_price: u64,
+    pub buyer_duration_index: u8,
+    pub asset_index_guidance: Vec<u64>,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub enum TimelockUpdateParams {
+    UpdateMarketInformation(Pubkey),
+    AddCollateral(AddCollateralTimeLockArgs),
+    UpdateLtv(UpdateMarketInformationParams),
+    RemoveCollateral(CollateralTerms),
+    UpdateApy(CollateralTerms),
+    UpdateStrategy(UpdateStrategyParams),
+    UpdateVault(u64),
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct TransferOrcaPositionParams {
+    pub liquidity_amount: u128,
+    pub token_max_a: u64,
+    pub token_max_b: u64,
+    pub tick_lower_index: i32,
+    pub tick_upper_index: i32,
+    pub asset_index_guidance: Vec<u64>,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct UpdateStrategyParams {
+    pub originations_enabled: Option<bool>,
+    pub liquidity_buffer: Option<u64>,
+    pub interest_fee: Option<u64>,
+    pub origination_fee: Option<u64>,
+    pub principal_fee: Option<u64>,
+    pub origination_cap: Option<u64>,
+    pub market_information: Option<Pubkey>,
+    pub external_yield_source_args: Option<ExternalYieldSourceArgs>,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct UpdateVaultParams {
+    pub deposits_enabled: bool,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct VaultStakeParams {
+    pub amount: u64,
+    pub stake_all: Option<bool>,
+    pub duration: u32,
+    pub duration_type: u8,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct WithdrawCollateralParams {
+    pub amount: u64,
+    pub collateral_index: u8,
+    pub weight_matrix: [[u32; 5]; 5],
+    pub asset_index_guidance: Vec<u64>,
+    pub expected_loan_values: ExpectedLoanValues,
+} 

--- a/programs/invest-in-sol/src/instructions/cpi/loopscale/types/mod.rs
+++ b/programs/invest-in-sol/src/instructions/cpi/loopscale/types/mod.rs
@@ -1,0 +1,9 @@
+pub mod pod;
+pub mod accounts;
+pub mod instructions;
+pub mod errors;
+
+pub use pod::*;
+pub use accounts::*;
+pub use instructions::*;
+pub use errors::*; 

--- a/programs/invest-in-sol/src/instructions/cpi/loopscale/types/pod.rs
+++ b/programs/invest-in-sol/src/instructions/cpi/loopscale/types/pod.rs
@@ -1,0 +1,127 @@
+use anchor_lang::prelude::*;
+use anchor_lang::{AnchorDeserialize, AnchorSerialize};
+use bytemuck::{Pod, Zeroable};
+
+/// represents a bool stored as a byte for some god awful reason
+#[repr(transparent)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Zeroable, Pod)]
+pub struct PodBool(u8);
+
+impl From<bool> for PodBool {
+    fn from(b: bool) -> Self {
+        PodBool(b as u8)
+    }
+}
+
+impl From<PodBool> for bool {
+    fn from(pb: PodBool) -> Self {
+        pb.0 != 0
+    }
+}
+
+/// represents a scaled decimal (scaled by 10^18)
+#[repr(C)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Zeroable, Pod, Default, Debug, PartialEq)]
+pub struct PodDecimal([u8; 24]);
+
+/// represents a 128-bit unsigned integer stored as little endian bytes
+#[repr(C)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Zeroable, Pod, Default, Debug, PartialEq)]
+pub struct PodU128([u8; 16]);
+
+impl From<u128> for PodU128 {
+    fn from(val: u128) -> Self {
+        PodU128(val.to_le_bytes())
+    }
+}
+
+impl From<PodU128> for u128 {
+    fn from(pod: PodU128) -> Self {
+        u128::from_le_bytes(pod.0)
+    }
+}
+
+/// represents a 16-bit unsigned integer stored as bytes (little-endian)
+#[repr(transparent)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Zeroable, Pod, Default, Debug, PartialEq)]
+pub struct PodU16([u8; 2]);
+
+impl From<u16> for PodU16 {
+    fn from(val: u16) -> Self {
+        PodU16(val.to_le_bytes())
+    }
+}
+
+impl From<PodU16> for u16 {
+    fn from(pod: PodU16) -> Self {
+        u16::from_le_bytes(pod.0)
+    }
+}
+
+/// represents a 32-bit unsigned integer stored as bytes (little-endian)
+#[repr(transparent)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Zeroable, Pod, Default, Debug, PartialEq)]
+pub struct PodU32([u8; 4]);
+
+impl From<u32> for PodU32 {
+    fn from(val: u32) -> Self {
+        PodU32(val.to_le_bytes())
+    }
+}
+
+impl From<PodU32> for u32 {
+    fn from(pod: PodU32) -> Self {
+        u32::from_le_bytes(pod.0)
+    }
+}
+
+/// Helper type to store u32 cbps values
+#[repr(C)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Zeroable, Pod, Default, Debug, PartialEq)]
+pub struct PodU32CBPS([u8; 4]);
+
+impl From<u32> for PodU32CBPS {
+    fn from(val: u32) -> Self {
+        PodU32CBPS(val.to_le_bytes())
+    }
+}
+
+impl From<PodU32CBPS> for u32 {
+    fn from(pod: PodU32CBPS) -> Self {
+        u32::from_le_bytes(pod.0)
+    }
+}
+
+/// represents a 64-bit unsigned integer stored as bytes (little-endian)
+#[repr(transparent)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Zeroable, Pod, Default, Debug, PartialEq)]
+pub struct PodU64([u8; 8]);
+
+impl From<u64> for PodU64 {
+    fn from(val: u64) -> Self {
+        PodU64(val.to_le_bytes())
+    }
+}
+
+impl From<PodU64> for u64 {
+    fn from(pod: PodU64) -> Self {
+        u64::from_le_bytes(pod.0)
+    }
+}
+
+/// Helper type to store u64 cbps values
+#[repr(C)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Zeroable, Pod, Default, Debug, PartialEq)]
+pub struct PodU64CBPS([u8; 8]);
+
+impl From<u64> for PodU64CBPS {
+    fn from(val: u64) -> Self {
+        PodU64CBPS(val.to_le_bytes())
+    }
+}
+
+impl From<PodU64CBPS> for u64 {
+    fn from(pod: PodU64CBPS) -> Self {
+        u64::from_le_bytes(pod.0)
+    }
+} 

--- a/programs/invest-in-sol/src/instructions/cpi/orca/cpi/fees.rs
+++ b/programs/invest-in-sol/src/instructions/cpi/orca/cpi/fees.rs
@@ -1,0 +1,134 @@
+use anchor_lang::prelude::*;
+use anchor_spl::token::{self, Token, TokenAccount};
+use whirlpool_cpi::{self, state::*, program::Whirlpool as WhirlpoolProgram};
+
+#[derive(Accounts)]
+pub struct CollectFees<'info> {
+    pub whirlpool_program: Program<'info, WhirlpoolProgram>,
+    
+    #[account(mut)]
+    pub position_authority: Signer<'info>,
+    
+    #[account(mut)]
+    pub position: AccountInfo<'info>,
+    
+    #[account(mut)]
+    pub position_token_account: Account<'info, TokenAccount>,
+    
+    #[account(mut)]
+    pub whirlpool: AccountInfo<'info>,
+    
+    #[account(mut)]
+    pub token_owner_account_a: Account<'info, TokenAccount>,
+    #[account(mut)]
+    pub token_owner_account_b: Account<'info, TokenAccount>,
+    
+    #[account(mut)]
+    pub token_vault_a: Account<'info, TokenAccount>,
+    #[account(mut)]
+    pub token_vault_b: Account<'info, TokenAccount>,
+    
+    pub token_program: Program<'info, Token>,
+}
+
+#[derive(Accounts)]
+pub struct CollectReward<'info> {
+    pub whirlpool_program: Program<'info, WhirlpoolProgram>,
+    
+    #[account(mut)]
+    pub position_authority: Signer<'info>,
+    
+    #[account(mut)]
+    pub position: AccountInfo<'info>,
+    
+    #[account(mut)]
+    pub position_token_account: Account<'info, TokenAccount>,
+    
+    #[account(mut)]
+    pub whirlpool: AccountInfo<'info>,
+    
+    #[account(mut)]
+    pub reward_owner_account: Account<'info, TokenAccount>,
+    #[account(mut)]
+    pub reward_vault: Account<'info, TokenAccount>,
+    
+    pub reward_authority: AccountInfo<'info>,
+    pub token_program: Program<'info, Token>,
+}
+
+#[derive(Accounts)]
+pub struct UpdateFeesAndRewards<'info> {
+    pub whirlpool_program: Program<'info, WhirlpoolProgram>,
+    
+    #[account(mut)]
+    pub whirlpool: AccountInfo<'info>,
+    
+    #[account(mut)]
+    pub position: AccountInfo<'info>,
+    
+    #[account(mut)]
+    pub tick_array_lower: AccountInfo<'info>,
+    #[account(mut)]
+    pub tick_array_upper: AccountInfo<'info>,
+}
+
+pub fn collect_fees<'a>(
+    ctx: CpiContext<'_, '_, '_, 'a, CollectFees<'a>>,
+) -> Result<()> {
+    let cpi_program = ctx.accounts.whirlpool_program.to_account_info();
+    let cpi_accounts = whirlpool_cpi::cpi::accounts::CollectFees {
+        position_authority: ctx.accounts.position_authority.to_account_info(),
+        position: ctx.accounts.position.to_account_info(),
+        position_token_account: ctx.accounts.position_token_account.to_account_info(),
+        whirlpool: ctx.accounts.whirlpool.to_account_info(),
+        token_owner_account_a: ctx.accounts.token_owner_account_a.to_account_info(),
+        token_owner_account_b: ctx.accounts.token_owner_account_b.to_account_info(),
+        token_vault_a: ctx.accounts.token_vault_a.to_account_info(),
+        token_vault_b: ctx.accounts.token_vault_b.to_account_info(),
+        token_program: ctx.accounts.token_program.to_account_info(),
+    };
+    
+    let cpi_ctx = CpiContext::new(cpi_program, cpi_accounts);
+    whirlpool_cpi::cpi::collect_fees(cpi_ctx)?;
+    
+    Ok(())
+}
+
+pub fn collect_reward<'a>(
+    ctx: CpiContext<'_, '_, '_, 'a, CollectReward<'a>>,
+    reward_index: u8,
+) -> Result<()> {
+    let cpi_program = ctx.accounts.whirlpool_program.to_account_info();
+    let cpi_accounts = whirlpool_cpi::cpi::accounts::CollectReward {
+        position_authority: ctx.accounts.position_authority.to_account_info(),
+        position: ctx.accounts.position.to_account_info(),
+        position_token_account: ctx.accounts.position_token_account.to_account_info(),
+        whirlpool: ctx.accounts.whirlpool.to_account_info(),
+        reward_owner_account: ctx.accounts.reward_owner_account.to_account_info(),
+        reward_vault: ctx.accounts.reward_vault.to_account_info(),
+        reward_authority: ctx.accounts.reward_authority.to_account_info(),
+        token_program: ctx.accounts.token_program.to_account_info(),
+    };
+    
+    let cpi_ctx = CpiContext::new(cpi_program, cpi_accounts);
+    whirlpool_cpi::cpi::collect_reward(cpi_ctx, reward_index)?;
+    
+    Ok(())
+}
+
+pub fn update_fees_and_rewards<'a>(
+    ctx: CpiContext<'_, '_, '_, 'a, UpdateFeesAndRewards<'a>>,
+) -> Result<()> {
+    let cpi_program = ctx.accounts.whirlpool_program.to_account_info();
+    let cpi_accounts = whirlpool_cpi::cpi::accounts::UpdateFeesAndRewards {
+        whirlpool: ctx.accounts.whirlpool.to_account_info(),
+        position: ctx.accounts.position.to_account_info(),
+        tick_array_lower: ctx.accounts.tick_array_lower.to_account_info(),
+        tick_array_upper: ctx.accounts.tick_array_upper.to_account_info(),
+    };
+    
+    let cpi_ctx = CpiContext::new(cpi_program, cpi_accounts);
+    whirlpool_cpi::cpi::update_fees_and_rewards(cpi_ctx)?;
+    
+    Ok(())
+} 

--- a/programs/invest-in-sol/src/instructions/cpi/orca/cpi/mod.rs
+++ b/programs/invest-in-sol/src/instructions/cpi/orca/cpi/mod.rs
@@ -1,0 +1,9 @@
+pub mod pool;
+pub mod position;
+pub mod swap;
+pub mod fees;
+
+pub use pool::*;
+pub use position::*;
+pub use swap::*;
+pub use fees::*; 

--- a/programs/invest-in-sol/src/instructions/cpi/orca/cpi/pool.rs
+++ b/programs/invest-in-sol/src/instructions/cpi/orca/cpi/pool.rs
@@ -1,0 +1,94 @@
+use anchor_lang::prelude::*;
+use anchor_spl::token::{self, Token, Mint, TokenAccount};
+use whirlpool_cpi::{self, state::*, program::Whirlpool as WhirlpoolProgram};
+use crate::cpi::orca::types::{InitializePoolParams};
+
+#[derive(Accounts)]
+pub struct InitializePool<'info> {
+    pub whirlpool_program: Program<'info, WhirlpoolProgram>,
+    
+    #[account(mut)]
+    pub whirlpools_config: AccountInfo<'info>,
+    
+    #[account(mut)]
+    pub token_mint_a: Account<'info, Mint>,
+    #[account(mut)]
+    pub token_mint_b: Account<'info, Mint>,
+    
+    #[account(mut)]
+    pub funder: Signer<'info>,
+    
+    #[account(mut)]
+    pub whirlpool: AccountInfo<'info>,
+    
+    #[account(mut)]
+    pub token_vault_a: Account<'info, TokenAccount>,
+    #[account(mut)]
+    pub token_vault_b: Account<'info, TokenAccount>,
+    
+    #[account(mut)]
+    pub fee_tier: AccountInfo<'info>,
+    
+    pub token_program: Program<'info, Token>,
+    pub system_program: Program<'info, System>,
+    pub rent: Sysvar<'info, Rent>,
+}
+
+#[derive(Accounts)]
+pub struct InitializeTickArray<'info> {
+    pub whirlpool_program: Program<'info, WhirlpoolProgram>,
+    
+    #[account(mut)]
+    pub whirlpool: AccountInfo<'info>,
+    
+    #[account(mut)]
+    pub funder: Signer<'info>,
+    
+    #[account(mut)]
+    pub tick_array: AccountInfo<'info>,
+    
+    pub system_program: Program<'info, System>,
+}
+
+pub fn initialize_pool<'a>(
+    ctx: CpiContext<'_, '_, '_, 'a, InitializePool<'a>>,
+    params: InitializePoolParams,
+) -> Result<()> {
+    let cpi_program = ctx.accounts.whirlpool_program.to_account_info();
+    let cpi_accounts = whirlpool_cpi::cpi::accounts::InitializePool {
+        whirlpools_config: ctx.accounts.whirlpools_config.to_account_info(),
+        token_mint_a: ctx.accounts.token_mint_a.to_account_info(),
+        token_mint_b: ctx.accounts.token_mint_b.to_account_info(),
+        funder: ctx.accounts.funder.to_account_info(),
+        whirlpool: ctx.accounts.whirlpool.to_account_info(),
+        token_vault_a: ctx.accounts.token_vault_a.to_account_info(),
+        token_vault_b: ctx.accounts.token_vault_b.to_account_info(),
+        fee_tier: ctx.accounts.fee_tier.to_account_info(),
+        token_program: ctx.accounts.token_program.to_account_info(),
+        system_program: ctx.accounts.system_program.to_account_info(),
+        rent: ctx.accounts.rent.to_account_info(),
+    };
+    
+    let cpi_ctx = CpiContext::new(cpi_program, cpi_accounts);
+    whirlpool_cpi::cpi::initialize_pool(cpi_ctx, params.tick_spacing, params.initial_sqrt_price)?;
+    
+    Ok(())
+}
+
+pub fn initialize_tick_array<'a>(
+    ctx: CpiContext<'_, '_, '_, 'a, InitializeTickArray<'a>>,
+    start_tick_index: i32,
+) -> Result<()> {
+    let cpi_program = ctx.accounts.whirlpool_program.to_account_info();
+    let cpi_accounts = whirlpool_cpi::cpi::accounts::InitializeTickArray {
+        whirlpool: ctx.accounts.whirlpool.to_account_info(),
+        funder: ctx.accounts.funder.to_account_info(),
+        tick_array: ctx.accounts.tick_array.to_account_info(),
+        system_program: ctx.accounts.system_program.to_account_info(),
+    };
+    
+    let cpi_ctx = CpiContext::new(cpi_program, cpi_accounts);
+    whirlpool_cpi::cpi::initialize_tick_array(cpi_ctx, start_tick_index)?;
+    
+    Ok(())
+} 

--- a/programs/invest-in-sol/src/instructions/cpi/orca/cpi/position.rs
+++ b/programs/invest-in-sol/src/instructions/cpi/orca/cpi/position.rs
@@ -1,0 +1,225 @@
+use anchor_lang::prelude::*;
+use anchor_spl::token::{self, Token, Mint, TokenAccount};
+use whirlpool_cpi::{self, state::*, program::Whirlpool as WhirlpoolProgram};
+use crate::cpi::orca::types::{OpenPositionParams, IncreaseLiquidityParams, DecreaseLiquidityParams};
+
+#[derive(Accounts)]
+pub struct OpenPosition<'info> {
+    pub whirlpool_program: Program<'info, WhirlpoolProgram>,
+    
+    #[account(mut)]
+    pub funder: Signer<'info>,
+    
+    #[account(mut)]
+    pub owner: Signer<'info>,
+    
+    #[account(mut)]
+    pub position: AccountInfo<'info>,
+    
+    #[account(mut)]
+    pub position_mint: Account<'info, Mint>,
+    
+    #[account(mut)]
+    pub position_token_account: Account<'info, TokenAccount>,
+    
+    #[account(mut)]
+    pub whirlpool: AccountInfo<'info>,
+    
+    pub system_program: Program<'info, System>,
+    pub token_program: Program<'info, Token>,
+    pub associated_token_program: Program<'info, AssociatedToken>,
+    pub rent: Sysvar<'info, Rent>,
+}
+
+#[derive(Accounts)]
+pub struct IncreaseLiquidity<'info> {
+    pub whirlpool_program: Program<'info, WhirlpoolProgram>,
+    
+    #[account(mut)]
+    pub position_authority: Signer<'info>,
+    
+    #[account(mut)]
+    pub position: AccountInfo<'info>,
+    
+    #[account(mut)]
+    pub position_token_account: Account<'info, TokenAccount>,
+    
+    #[account(mut)]
+    pub whirlpool: AccountInfo<'info>,
+    
+    #[account(mut)]
+    pub token_owner_account_a: Account<'info, TokenAccount>,
+    #[account(mut)]
+    pub token_owner_account_b: Account<'info, TokenAccount>,
+    
+    #[account(mut)]
+    pub token_vault_a: Account<'info, TokenAccount>,
+    #[account(mut)]
+    pub token_vault_b: Account<'info, TokenAccount>,
+    
+    #[account(mut)]
+    pub tick_array_lower: AccountInfo<'info>,
+    #[account(mut)]
+    pub tick_array_upper: AccountInfo<'info>,
+    
+    pub token_program: Program<'info, Token>,
+}
+
+#[derive(Accounts)]
+pub struct DecreaseLiquidity<'info> {
+    pub whirlpool_program: Program<'info, WhirlpoolProgram>,
+    
+    #[account(mut)]
+    pub position_authority: Signer<'info>,
+    
+    #[account(mut)]
+    pub position: AccountInfo<'info>,
+    
+    #[account(mut)]
+    pub position_token_account: Account<'info, TokenAccount>,
+    
+    #[account(mut)]
+    pub whirlpool: AccountInfo<'info>,
+    
+    #[account(mut)]
+    pub token_owner_account_a: Account<'info, TokenAccount>,
+    #[account(mut)]
+    pub token_owner_account_b: Account<'info, TokenAccount>,
+    
+    #[account(mut)]
+    pub token_vault_a: Account<'info, TokenAccount>,
+    #[account(mut)]
+    pub token_vault_b: Account<'info, TokenAccount>,
+    
+    #[account(mut)]
+    pub tick_array_lower: AccountInfo<'info>,
+    #[account(mut)]
+    pub tick_array_upper: AccountInfo<'info>,
+    
+    pub token_program: Program<'info, Token>,
+}
+
+#[derive(Accounts)]
+pub struct ClosePosition<'info> {
+    pub whirlpool_program: Program<'info, WhirlpoolProgram>,
+    
+    #[account(mut)]
+    pub position_authority: Signer<'info>,
+    
+    #[account(mut)]
+    pub receiver: AccountInfo<'info>,
+    
+    #[account(mut)]
+    pub position: AccountInfo<'info>,
+    
+    #[account(mut)]
+    pub position_mint: Account<'info, Mint>,
+    
+    #[account(mut)]
+    pub position_token_account: Account<'info, TokenAccount>,
+    
+    pub token_program: Program<'info, Token>,
+}
+
+pub fn open_position<'a>(
+    ctx: CpiContext<'_, '_, '_, 'a, OpenPosition<'a>>,
+    params: OpenPositionParams,
+) -> Result<()> {
+    let cpi_program = ctx.accounts.whirlpool_program.to_account_info();
+    let cpi_accounts = whirlpool_cpi::cpi::accounts::OpenPosition {
+        funder: ctx.accounts.funder.to_account_info(),
+        owner: ctx.accounts.owner.to_account_info(),
+        position: ctx.accounts.position.to_account_info(),
+        position_mint: ctx.accounts.position_mint.to_account_info(),
+        position_token_account: ctx.accounts.position_token_account.to_account_info(),
+        whirlpool: ctx.accounts.whirlpool.to_account_info(),
+        system_program: ctx.accounts.system_program.to_account_info(),
+        token_program: ctx.accounts.token_program.to_account_info(),
+        associated_token_program: ctx.accounts.associated_token_program.to_account_info(),
+        rent: ctx.accounts.rent.to_account_info(),
+    };
+    
+    let cpi_ctx = CpiContext::new(cpi_program, cpi_accounts);
+    whirlpool_cpi::cpi::open_position(cpi_ctx, params.tick_lower_index, params.tick_upper_index)?;
+    
+    Ok(())
+}
+
+pub fn increase_liquidity<'a>(
+    ctx: CpiContext<'_, '_, '_, 'a, IncreaseLiquidity<'a>>,
+    params: IncreaseLiquidityParams,
+) -> Result<()> {
+    let cpi_program = ctx.accounts.whirlpool_program.to_account_info();
+    let cpi_accounts = whirlpool_cpi::cpi::accounts::IncreaseLiquidity {
+        position_authority: ctx.accounts.position_authority.to_account_info(),
+        position: ctx.accounts.position.to_account_info(),
+        position_token_account: ctx.accounts.position_token_account.to_account_info(),
+        whirlpool: ctx.accounts.whirlpool.to_account_info(),
+        token_owner_account_a: ctx.accounts.token_owner_account_a.to_account_info(),
+        token_owner_account_b: ctx.accounts.token_owner_account_b.to_account_info(),
+        token_vault_a: ctx.accounts.token_vault_a.to_account_info(),
+        token_vault_b: ctx.accounts.token_vault_b.to_account_info(),
+        tick_array_lower: ctx.accounts.tick_array_lower.to_account_info(),
+        tick_array_upper: ctx.accounts.tick_array_upper.to_account_info(),
+        token_program: ctx.accounts.token_program.to_account_info(),
+    };
+    
+    let cpi_ctx = CpiContext::new(cpi_program, cpi_accounts);
+    whirlpool_cpi::cpi::increase_liquidity(
+        cpi_ctx,
+        params.liquidity_amount,
+        params.token_max_a,
+        params.token_max_b,
+    )?;
+    
+    Ok(())
+}
+
+pub fn decrease_liquidity<'a>(
+    ctx: CpiContext<'_, '_, '_, 'a, DecreaseLiquidity<'a>>,
+    params: DecreaseLiquidityParams,
+) -> Result<()> {
+    let cpi_program = ctx.accounts.whirlpool_program.to_account_info();
+    let cpi_accounts = whirlpool_cpi::cpi::accounts::DecreaseLiquidity {
+        position_authority: ctx.accounts.position_authority.to_account_info(),
+        position: ctx.accounts.position.to_account_info(),
+        position_token_account: ctx.accounts.position_token_account.to_account_info(),
+        whirlpool: ctx.accounts.whirlpool.to_account_info(),
+        token_owner_account_a: ctx.accounts.token_owner_account_a.to_account_info(),
+        token_owner_account_b: ctx.accounts.token_owner_account_b.to_account_info(),
+        token_vault_a: ctx.accounts.token_vault_a.to_account_info(),
+        token_vault_b: ctx.accounts.token_vault_b.to_account_info(),
+        tick_array_lower: ctx.accounts.tick_array_lower.to_account_info(),
+        tick_array_upper: ctx.accounts.tick_array_upper.to_account_info(),
+        token_program: ctx.accounts.token_program.to_account_info(),
+    };
+    
+    let cpi_ctx = CpiContext::new(cpi_program, cpi_accounts);
+    whirlpool_cpi::cpi::decrease_liquidity(
+        cpi_ctx,
+        params.liquidity_amount,
+        params.token_min_a,
+        params.token_min_b,
+    )?;
+    
+    Ok(())
+}
+
+pub fn close_position<'a>(
+    ctx: CpiContext<'_, '_, '_, 'a, ClosePosition<'a>>,
+) -> Result<()> {
+    let cpi_program = ctx.accounts.whirlpool_program.to_account_info();
+    let cpi_accounts = whirlpool_cpi::cpi::accounts::ClosePosition {
+        position_authority: ctx.accounts.position_authority.to_account_info(),
+        receiver: ctx.accounts.receiver.to_account_info(),
+        position: ctx.accounts.position.to_account_info(),
+        position_mint: ctx.accounts.position_mint.to_account_info(),
+        position_token_account: ctx.accounts.position_token_account.to_account_info(),
+        token_program: ctx.accounts.token_program.to_account_info(),
+    };
+    
+    let cpi_ctx = CpiContext::new(cpi_program, cpi_accounts);
+    whirlpool_cpi::cpi::close_position(cpi_ctx)?;
+    
+    Ok(())
+} 

--- a/programs/invest-in-sol/src/instructions/cpi/orca/cpi/swap.rs
+++ b/programs/invest-in-sol/src/instructions/cpi/orca/cpi/swap.rs
@@ -1,0 +1,69 @@
+use anchor_lang::prelude::*;
+use anchor_spl::token::{self, Token, TokenAccount};
+use whirlpool_cpi::{self, state::*, program::Whirlpool as WhirlpoolProgram};
+use crate::cpi::orca::types::SwapParams;
+
+#[derive(Accounts)]
+pub struct Swap<'info> {
+    pub whirlpool_program: Program<'info, WhirlpoolProgram>,
+    
+    #[account(mut)]
+    pub token_authority: Signer<'info>,
+    
+    #[account(mut)]
+    pub whirlpool: AccountInfo<'info>,
+    
+    #[account(mut)]
+    pub token_owner_account_a: Account<'info, TokenAccount>,
+    #[account(mut)]
+    pub token_vault_a: Account<'info, TokenAccount>,
+    
+    #[account(mut)]
+    pub token_owner_account_b: Account<'info, TokenAccount>,
+    #[account(mut)]
+    pub token_vault_b: Account<'info, TokenAccount>,
+    
+    #[account(mut)]
+    pub tick_array_0: AccountInfo<'info>,
+    #[account(mut)]
+    pub tick_array_1: AccountInfo<'info>,
+    #[account(mut)]
+    pub tick_array_2: AccountInfo<'info>,
+    
+    #[account(mut)]
+    pub oracle: AccountInfo<'info>,
+    
+    pub token_program: Program<'info, Token>,
+}
+
+pub fn swap<'a>(
+    ctx: CpiContext<'_, '_, '_, 'a, Swap<'a>>,
+    params: SwapParams,
+) -> Result<()> {
+    let cpi_program = ctx.accounts.whirlpool_program.to_account_info();
+    let cpi_accounts = whirlpool_cpi::cpi::accounts::Swap {
+        whirlpool: ctx.accounts.whirlpool.to_account_info(),
+        token_authority: ctx.accounts.token_authority.to_account_info(),
+        token_owner_account_a: ctx.accounts.token_owner_account_a.to_account_info(),
+        token_vault_a: ctx.accounts.token_vault_a.to_account_info(),
+        token_owner_account_b: ctx.accounts.token_owner_account_b.to_account_info(),
+        token_vault_b: ctx.accounts.token_vault_b.to_account_info(),
+        tick_array_0: ctx.accounts.tick_array_0.to_account_info(),
+        tick_array_1: ctx.accounts.tick_array_1.to_account_info(),
+        tick_array_2: ctx.accounts.tick_array_2.to_account_info(),
+        oracle: ctx.accounts.oracle.to_account_info(),
+        token_program: ctx.accounts.token_program.to_account_info(),
+    };
+    
+    let cpi_ctx = CpiContext::new(cpi_program, cpi_accounts);
+    whirlpool_cpi::cpi::swap(
+        cpi_ctx,
+        params.amount,
+        params.other_amount_threshold,
+        params.sqrt_price_limit,
+        params.amount_specified_is_input,
+        params.a_to_b,
+    )?;
+    
+    Ok(())
+} 

--- a/programs/invest-in-sol/src/instructions/cpi/orca/cpi/verify.rs
+++ b/programs/invest-in-sol/src/instructions/cpi/orca/cpi/verify.rs
@@ -1,0 +1,23 @@
+use anchor_lang::prelude::*;
+use whirlpool_cpi::{self, state::*, program::Whirlpool as WhirlpoolProgram};
+
+#[derive(Accounts)]
+pub struct VerifyAccount<'info> {
+    pub whirlpool_program: Program<'info, WhirlpoolProgram>,
+    
+    pub account: AccountInfo<'info>,
+}
+
+pub fn verify_account<'a>(
+    ctx: CpiContext<'_, '_, '_, 'a, VerifyAccount<'a>>,
+) -> Result<()> {
+    let cpi_program = ctx.accounts.whirlpool_program.to_account_info();
+    let cpi_accounts = whirlpool_cpi::cpi::accounts::VerifyAccount {
+        account: ctx.accounts.account.to_account_info(),
+    };
+    
+    let cpi_ctx = CpiContext::new(cpi_program, cpi_accounts);
+    whirlpool_cpi::cpi::verify_account(cpi_ctx)?;
+    
+    Ok(())
+} 

--- a/programs/invest-in-sol/src/instructions/cpi/orca/types/accounts.rs
+++ b/programs/invest-in-sol/src/instructions/cpi/orca/types/accounts.rs
@@ -1,0 +1,60 @@
+use anchor_lang::prelude::*;
+use anchor_lang::{AnchorDeserialize, AnchorSerialize};
+use bytemuck::{Pod, Zeroable};
+
+#[repr(C)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Zeroable, Pod, Debug, PartialEq)]
+pub struct OrcaPoolConfig {
+    pub version: u8,
+    pub bump: u8,
+    pub authority: Pubkey,
+    pub whirlpool: Pubkey,
+    pub token_mint_a: Pubkey,
+    pub token_mint_b: Pubkey,
+    pub token_vault_a: Pubkey,
+    pub token_vault_b: Pubkey,
+    pub tick_spacing: i32,
+    pub fee_rate: u16,
+    pub protocol_fee_rate: u16,
+    pub liquidity: u128,
+    pub sqrt_price: u128,
+    pub tick_current_index: i32,
+    pub fee_growth_global_a: u128,
+    pub fee_growth_global_b: u128,
+    pub protocol_fee_owed_a: u64,
+    pub protocol_fee_owed_b: u64,
+    pub reward_infos: [RewardInfo; 3],
+}
+
+#[repr(C)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Zeroable, Pod, Debug, PartialEq)]
+pub struct RewardInfo {
+    pub mint: Pubkey,
+    pub vault: Pubkey,
+    pub authority: Pubkey,
+    pub emissions_per_second_x64: u128,
+    pub growth_global_x64: u128,
+}
+
+#[repr(C)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Zeroable, Pod, Debug, PartialEq)]
+pub struct Position {
+    pub bump: u8,
+    pub position_mint: Pubkey,
+    pub whirlpool: Pubkey,
+    pub liquidity: u128,
+    pub tick_lower_index: i32,
+    pub tick_upper_index: i32,
+    pub fee_growth_checkpoint_a: u128,
+    pub fee_growth_checkpoint_b: u128,
+    pub protocol_fee_owed_a: u64,
+    pub protocol_fee_owed_b: u64,
+    pub reward_infos: [PositionRewardInfo; 3],
+}
+
+#[repr(C)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Zeroable, Pod, Debug, PartialEq)]
+pub struct PositionRewardInfo {
+    pub growth_inside_checkpoint: u128,
+    pub amount_owed: u64,
+} 

--- a/programs/invest-in-sol/src/instructions/cpi/orca/types/instructions.rs
+++ b/programs/invest-in-sol/src/instructions/cpi/orca/types/instructions.rs
@@ -1,0 +1,36 @@
+use anchor_lang::prelude::*;
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct InitializePoolParams {
+    pub tick_spacing: i32,
+    pub initial_sqrt_price: u128,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct OpenPositionParams {
+    pub tick_lower_index: i32,
+    pub tick_upper_index: i32,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct IncreaseLiquidityParams {
+    pub liquidity_amount: u128,
+    pub token_max_a: u64,
+    pub token_max_b: u64,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct DecreaseLiquidityParams {
+    pub liquidity_amount: u128,
+    pub token_min_a: u64,
+    pub token_min_b: u64,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq)]
+pub struct SwapParams {
+    pub amount: u64,
+    pub other_amount_threshold: u64,
+    pub sqrt_price_limit: u128,
+    pub amount_specified_is_input: bool,
+    pub a_to_b: bool,
+} 

--- a/programs/invest-in-sol/src/instructions/cpi/orca/types/mod.rs
+++ b/programs/invest-in-sol/src/instructions/cpi/orca/types/mod.rs
@@ -1,0 +1,5 @@
+pub mod accounts;
+pub mod instructions;
+
+pub use accounts::*;
+pub use instructions::*; 

--- a/programs/invest-in-sol/src/instructions/lend.rs
+++ b/programs/invest-in-sol/src/instructions/lend.rs
@@ -1,0 +1,179 @@
+use anchor_lang::prelude::*;
+use anchor_spl::{
+    token::{Token, TokenAccount, Mint, mint_to},
+    associated_token::AssociatedToken,
+};
+use crate::{state::*, error::*};
+use crate::instructions::loopscale::cpi::{strategy::*, vault::*};
+
+#[derive(Accounts)]
+pub struct LendTreasurySol<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+
+    /// treasury PDA that holds the SOL
+    #[account(
+        mut,
+        seeds = [b"treasury"],
+        bump = treasury.bump,
+    )]
+    pub treasury: Account<'info, Treasury>,
+
+    /// CHECK: validated by loopscale program
+    #[account(mut)]
+    pub loopscale_strategy: AccountInfo<'info>,
+
+    /// CHECK: validated by loopscale program
+    pub market_information: AccountInfo<'info>,
+
+    /// WSOL mint
+    #[account(
+        mut,
+        address = anchor_spl::token::spl_token::native_mint::ID
+    )]
+    pub wsol_mint: Account<'info, Mint>,
+
+    /// treasury's wrapped SOL account
+    #[account(
+        mut,
+        constraint = treasury_wsol_account.owner == treasury.key(),
+        constraint = treasury_wsol_account.mint == wsol_mint.key()
+    )]
+    pub treasury_wsol_account: Box<Account<'info, TokenAccount>>,
+
+    /// CHECK: validated by loopscale program
+    #[account(mut)]
+    pub strategy_wsol_account: AccountInfo<'info>,
+
+    pub token_program: Program<'info, Token>,
+    pub associated_token_program: Program<'info, AssociatedToken>,
+    pub system_program: Program<'info, System>,
+
+    /// CHECK: validated by loopscale program
+    pub event_authority: AccountInfo<'info>,
+
+    /// CHECK: validated by loopscale program
+    pub loopscale_program: AccountInfo<'info>,
+}
+
+pub fn lend_treasury_sol(ctx: Context<LendTreasurySol>, amount: u64) -> Result<()> {
+    // verify the treasury has enough native SOL
+    require!(
+        ctx.accounts.treasury.to_account_info().lamports() >= amount,
+        ErrorCode::InsufficientTreasuryBalance
+    );
+
+    // verify amount is not zero
+    require!(amount > 0, ErrorCode::InvalidAmount);
+
+    // create CPI context for loopscale deposit
+    let cpi_accounts = CreateStrategy {
+        payer: ctx.accounts.authority.to_account_info(),
+        manager: ctx.accounts.authority.to_account_info(),
+        strategy: ctx.accounts.loopscale_strategy.to_account_info(),
+        principal_mint: ctx.accounts.wsol_mint.to_account_info(),
+        system_program: ctx.accounts.system_program.to_account_info(),
+        event_authority: ctx.accounts.event_authority.to_account_info(),
+        program: ctx.accounts.loopscale_program.to_account_info(),
+    };
+
+    let cpi_ctx = CpiContext::new(
+        ctx.accounts.loopscale_program.to_account_info(),
+        cpi_accounts,
+    );
+
+    // create strategy params
+    let strategy_params = CreateStrategyParams {
+        lender: ctx.accounts.treasury.key(),
+        origination_cap: amount,
+        liquidity_buffer: 0, // no buffer needed for treasury lending
+        interest_fee: 0, // no fee for treasury lending
+        origination_fee: 0, // no origination fee
+        principal_fee: 0, // no principal fee
+        originations_enabled: true,
+        external_yield_source_args: None,
+    };
+
+    // create the strategy
+    create_strategy(cpi_ctx, strategy_params)?;
+
+    // convert native SOL to WSOL
+    let seeds = &[
+        b"treasury".as_ref(),
+        &[ctx.accounts.treasury.bump],
+    ];
+    let signer = &[&seeds[..]];
+
+    // verify WSOL mint is valid
+    require!(
+        ctx.accounts.wsol_mint.key() == anchor_spl::token::spl_token::native_mint::ID,
+        ErrorCode::InvalidMint
+    );
+
+    // verify treasury WSOL account exists and is valid
+    if ctx.accounts.treasury_wsol_account.to_account_info().owner != &anchor_spl::token::ID {
+        // create WSOL account if it doesn't exist
+        let create_ata_accounts = anchor_spl::associated_token::Create {
+            payer: ctx.accounts.treasury.to_account_info(),
+            associated_token: ctx.accounts.treasury_wsol_account.to_account_info(),
+            authority: ctx.accounts.treasury.to_account_info(),
+            mint: ctx.accounts.wsol_mint.to_account_info(),
+            system_program: ctx.accounts.system_program.to_account_info(),
+            token_program: ctx.accounts.token_program.to_account_info(),
+        };
+
+        let cpi_ctx = CpiContext::new_with_signer(
+            ctx.accounts.associated_token_program.to_account_info(),
+            create_ata_accounts,
+            signer,
+        );
+
+        anchor_spl::associated_token::create(cpi_ctx)?;
+    }
+
+    // mint WSOL to treasury's WSOL account
+    let mint_to_accounts = anchor_spl::token::MintTo {
+        mint: ctx.accounts.wsol_mint.to_account_info(),
+        to: ctx.accounts.treasury_wsol_account.to_account_info(),
+        authority: ctx.accounts.treasury.to_account_info(),
+    };
+
+    let cpi_ctx = CpiContext::new_with_signer(
+        ctx.accounts.token_program.to_account_info(),
+        mint_to_accounts,
+        signer,
+    );
+
+    // verify mint was successful
+    let pre_balance = ctx.accounts.treasury_wsol_account.amount;
+    mint_to(cpi_ctx, amount)?;
+    let post_balance = ctx.accounts.treasury_wsol_account.amount;
+    require!(
+        post_balance == pre_balance + amount,
+        ErrorCode::MintFailed
+    );
+
+    // transfer WSOL to strategy
+    let transfer_accounts = anchor_spl::token::Transfer {
+        from: ctx.accounts.treasury_wsol_account.to_account_info(),
+        to: ctx.accounts.strategy_wsol_account.to_account_info(),
+        authority: ctx.accounts.treasury.to_account_info(),
+    };
+
+    let cpi_ctx = CpiContext::new_with_signer(
+        ctx.accounts.token_program.to_account_info(),
+        transfer_accounts,
+        signer,
+    );
+
+    // verify transfer was successful
+    let pre_transfer_balance = ctx.accounts.treasury_wsol_account.amount;
+    anchor_spl::token::transfer(cpi_ctx, amount)?;
+    let post_transfer_balance = ctx.accounts.treasury_wsol_account.amount;
+    require!(
+        post_transfer_balance == pre_transfer_balance - amount,
+        ErrorCode::TransferFailed
+    );
+
+    Ok(())
+}

--- a/programs/invest-in-sol/src/instructions/lp.rs
+++ b/programs/invest-in-sol/src/instructions/lp.rs
@@ -1,0 +1,97 @@
+use anchor_lang::prelude::*;
+use anchor_spl::token::{self, Token, Mint, TokenAccount};
+use crate::cpi::orca::types::{OrcaPoolConfig, InitializePoolParams};
+use whirlpool_cpi::{self, state::*, program::Whirlpool as WhirlpoolProgram};
+
+#[derive(Accounts)]
+pub struct InitializeOrcaPool<'info> {
+    #[account(
+        init,
+        payer = payer,
+        space = 8 + std::mem::size_of::<OrcaPoolConfig>(),
+        seeds = [b"orca-pool-config", token_mint_a.key().as_ref(), token_mint_b.key().as_ref()],
+        bump
+    )]
+    pub pool_config: Account<'info, OrcaPoolConfig>,
+    
+    pub whirlpool_program: Program<'info, WhirlpoolProgram>,
+    
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    
+    pub token_mint_a: Account<'info, Mint>,
+    pub token_mint_b: Account<'info, Mint>,
+    
+    #[account(mut)]
+    pub token_vault_a: Account<'info, TokenAccount>,
+    #[account(mut)]
+    pub token_vault_b: Account<'info, TokenAccount>,
+    
+    pub system_program: Program<'info, System>,
+    pub token_program: Program<'info, Token>,
+}
+
+#[derive(Accounts)]
+pub struct UpdateOrcaPoolConfig<'info> {
+    #[account(
+        mut,
+        has_one = authority,
+        seeds = [b"orca-pool-config", pool_config.token_mint_a.as_ref(), pool_config.token_mint_b.as_ref()],
+        bump = pool_config.bump
+    )]
+    pub pool_config: Account<'info, OrcaPoolConfig>,
+    
+    pub authority: Signer<'info>,
+}
+
+pub fn initialize_orca_pool(
+    ctx: Context<InitializeOrcaPool>,
+    params: InitializePoolParams,
+) -> Result<()> {
+    let pool_config = &mut ctx.accounts.pool_config;
+    
+    // initialize the whirlpool
+    let cpi_program = ctx.accounts.whirlpool_program.to_account_info();
+    let cpi_accounts = whirlpool_cpi::cpi::accounts::InitializePool {
+        whirlpools_config: ctx.accounts.whirlpools_config.to_account_info(),
+        token_mint_a: ctx.accounts.token_mint_a.to_account_info(),
+        token_mint_b: ctx.accounts.token_mint_b.to_account_info(),
+        funder: ctx.accounts.payer.to_account_info(),
+        whirlpool: ctx.accounts.whirlpool.to_account_info(),
+        token_vault_a: ctx.accounts.token_vault_a.to_account_info(),
+        token_vault_b: ctx.accounts.token_vault_b.to_account_info(),
+        fee_tier: ctx.accounts.fee_tier.to_account_info(),
+        token_program: ctx.accounts.token_program.to_account_info(),
+        system_program: ctx.accounts.system_program.to_account_info(),
+        rent: ctx.accounts.rent.to_account_info(),
+    };
+    
+    let cpi_ctx = CpiContext::new(cpi_program, cpi_accounts);
+    whirlpool_cpi::cpi::initialize_pool(cpi_ctx, params.tick_spacing, params.initial_sqrt_price)?;
+    
+    // initialize the pool config
+    pool_config.version = 1;
+    pool_config.bump = *ctx.bumps.get("pool_config").unwrap();
+    pool_config.authority = ctx.accounts.payer.key();
+    pool_config.whirlpool = ctx.accounts.whirlpool.key();
+    pool_config.token_mint_a = ctx.accounts.token_mint_a.key();
+    pool_config.token_mint_b = ctx.accounts.token_mint_b.key();
+    pool_config.token_vault_a = ctx.accounts.token_vault_a.key();
+    pool_config.token_vault_b = ctx.accounts.token_vault_b.key();
+    
+    Ok(())
+}
+
+pub fn update_orca_pool_config(
+    ctx: Context<UpdateOrcaPoolConfig>,
+    new_config: OrcaPoolConfig,
+) -> Result<()> {
+    let pool_config = &mut ctx.accounts.pool_config;
+    
+    // update the config with new values
+    pool_config.fee_rate = new_config.fee_rate;
+    pool_config.protocol_fee_rate = new_config.protocol_fee_rate;
+    pool_config.reward_infos = new_config.reward_infos;
+    
+    Ok(())
+} 

--- a/programs/invest-in-sol/src/instructions/mod.rs
+++ b/programs/invest-in-sol/src/instructions/mod.rs
@@ -1,5 +1,5 @@
 pub mod deposit;
 pub mod initialize;
-
-pub use deposit::*;
+pub mod orca;
+// pub use deposit::*;
 pub use initialize::*;

--- a/programs/invest-in-sol/src/state/config.rs
+++ b/programs/invest-in-sol/src/state/config.rs
@@ -9,6 +9,10 @@ pub struct Config {
     pub authority: Option<Pubkey>,
     /// The address of the Convertible Note we'll be issuing.
     pub cn_mint: Pubkey,
+    /// The address of the Convertible Note we'll be issuing.
+    pub pt_mint: Pubkey,
+    /// The address of the options NFT collection.
+    pub collection_mint: Pubkey,
     /// The optional fee for using the protocol.
     pub fee: Option<u16>,
     /// Used to lock the protocol.
@@ -16,7 +20,7 @@ pub struct Config {
     /// The bump used to generate this Config account.
     pub config_bump: u8,
     /// The bump used to generate the LP account.
-    pub lp_bump: u8,
+    pub pt_bump: u8,
     /// The bump used to generate the treasury account.
     pub treasury_bump: u8,
 }

--- a/programs/invest-in-sol/src/state/treasury.rs
+++ b/programs/invest-in-sol/src/state/treasury.rs
@@ -1,4 +1,11 @@
 use anchor_lang::prelude::*;
+//    - A treasury PDA
+//        - Holds:
+//            - CN / PT token account references
+//            - Ability to hold sol
+//            - address of LP Token look up table
+//        - methods:
+//          - update look up table, takes address which must be 
 
 #[account]
 #[derive(InitSpace)]
@@ -6,5 +13,7 @@ pub struct Treasury {
     /// The seed used to generate this Treasury account.
     pub seed: u64,
     /// The authority that can update the treasury.
-    pub authority: Option<Pubkey>,
+    pub authority: Option<Pubkey>
 }
+
+

--- a/tests/deposit.ts
+++ b/tests/deposit.ts
@@ -1,0 +1,56 @@
+import * as anchor from "@coral-xyz/anchor";
+import { Program } from "@coral-xyz/anchor";
+import { InvestInSol } from "../target/types/invest_in_sol";
+// What do we initialize: 
+//    - Tokens (Convertible note and protocol token)
+//    - NFT Collection
+//    - A vault pda
+//        - Holds: 
+//            - PT
+//            - Mint authority / Metadata authority for nfts
+describe("does initialize the protocol", () => {
+  // Configure the client to use the local cluster.
+  anchor.setProvider(anchor.AnchorProvider.env());
+
+  const program = anchor.workspace.investInSol as Program<InvestInSol>;
+
+
+  it("swaps USDC -> SOL", async () => {
+    // Add your test here.
+    const tx = await program.methods.initialize().rpc();
+    console.log("Your transaction signature", tx);
+
+    // get starting USDC balance on devnet
+
+    // get starting SOL balance on devnet
+
+    // get quote
+
+    // swap USDC to sol
+  });
+
+  it("mints protocol token, transfers token to vault", async () => {
+    // Add your test here.
+    const tx = await program.methods.initialize().rpc();
+    console.log("Your transaction signature", tx);
+  });
+
+  it("creates NFT metadata account", async () => {
+    // Add your test here.
+    const tx = await program.methods.initialize().rpc();
+    console.log("Your transaction signature", tx);
+  });
+
+  it("mints NFT to user", async () => {
+    // Add your test here.
+    const tx = await program.methods.initialize().rpc();
+    console.log("Your transaction signature", tx);
+  });
+
+  it("mints protocol token, transfers fee to protocol and remaining tokens to depositor", async () => {
+    // Add your test here.
+    const tx = await program.methods.initialize().rpc();
+    console.log("Your transaction signature", tx);
+  });
+
+});

--- a/tests/initialize.ts
+++ b/tests/initialize.ts
@@ -1,0 +1,65 @@
+import * as anchor from "@coral-xyz/anchor";
+import { Program } from "@coral-xyz/anchor";
+import { InvestInSol } from "../target/types/invest_in_sol";
+// What do we initialize: 
+//    - Tokens (Convertible note and protocol token)
+//    - NFT Collection
+//    - A vault pda
+//        - Holds: 
+//            - PT
+//            - Mint authority / Metadata authority for nfts
+describe("does initialize the protocol", () => {
+  // Configure the client to use the local cluster.
+  anchor.setProvider(anchor.AnchorProvider.env());
+
+  const program = anchor.workspace.investInSol as Program<InvestInSol>;
+  
+  it("creates vault PDA", async () => {
+    // Add your test here.
+    const tx = await program.methods.initialize().rpc();
+    console.log("Your transaction signature", tx);
+
+    // now generate PDA account address via seed and confirm the account exists on-chain
+
+  });
+
+  it("creates treasury PDA", async () => {
+    // Add your test here.
+    const tx = await program.methods.initialize().rpc();
+    console.log("Your transaction signature", tx);
+
+    // now generate PDA account address via seed and confirm it exists on-chain
+
+  });
+  
+  it("creates convertible note token", async () => {
+    // Add your test here.
+    const tx = await program.methods.initialize().rpc();
+    console.log("Your transaction signature", tx);
+
+    // get total supply, should be 0. 
+
+    // get metadata for token, check name
+
+  });
+
+  it("creates protocol token", async () => {
+    // Add your test here.
+    const tx = await program.methods.initialize().rpc();
+    console.log("Your transaction signature", tx);
+
+    // get total supply, should be 0. 
+
+    // get metadata for token, check name
+
+  });
+
+  it("creates NFT collection", async () => {
+    // Add your test here.
+    const tx = await program.methods.initialize().rpc();
+    console.log("Your transaction signature", tx);
+  });
+
+  // 
+
+});

--- a/tests/lp.ts
+++ b/tests/lp.ts
@@ -1,0 +1,69 @@
+import * as anchor from "@coral-xyz/anchor";
+import { Program } from "@coral-xyz/anchor";
+import { InvestInSol } from "../target/types/invest_in_sol";
+// What do we initialize: 
+//    - Tokens (Convertible note and protocol token)
+//    - NFT Collection
+//    - A vault pda
+//        - Holds: 
+//            - PT
+//            - Mint authority / Metadata authority for nfts
+describe("does initialize the protocol", () => {
+  // Configure the client to use the local cluster.
+  anchor.setProvider(anchor.AnchorProvider.env());
+
+  const program = anchor.workspace.investInSol as Program<InvestInSol>;
+  
+  it("deploy LP pool config account", async () => {
+    // Add your test here.
+    const tx = await program.methods.initialize().rpc();
+    console.log("Your transaction signature", tx);
+
+    // now generate PDA account address via seed and confirm it exists on-chain
+
+  });
+
+  it("create LP pool", async () => {
+    // Add your test here.
+    const tx = await program.methods.initialize().rpc();
+    console.log("Your transaction signature", tx);
+
+
+    // now generate PDA account address via seed and confirm it exists on-chain
+
+  });
+  
+  it("create LP position", async () => {
+    // Add your test here.
+    const tx = await program.methods.initialize().rpc();
+    console.log("Your transaction signature", tx);
+
+    // get total supply, should be 0. 
+
+    // get metadata for token, check name
+
+  });
+
+  it("performs swap", async () => {
+    // Add your test here.
+    const tx = await program.methods.initialize().rpc();
+    console.log("Your transaction signature", tx);
+  });
+
+  it("checks LP position, returns token a / b balance + quote", async () => {
+    // Add your test here.
+    const tx = await program.methods.initialize().rpc();
+    console.log("Your transaction signature", tx);
+  });
+
+
+  it("collects fees", async () => {
+    // Add your test here.
+    const tx = await program.methods.initialize().rpc();
+    console.log("Your transaction signature", tx);
+
+  });
+
+  // 
+
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,34 +9,36 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@coral-xyz/anchor-errors@^0.31.0":
-  version "0.31.0"
-  resolved "https://registry.yarnpkg.com/@coral-xyz/anchor-errors/-/anchor-errors-0.31.0.tgz#dfc7329fca152b598842f68175efe5000825b51b"
-  integrity sha512-SUERksFSQ+4F11hkROIwHq4mcoSMXJxwVWLoklefi4dU679zVWFVcTq6O7otvjY8wlUaRXeE+iYcQWZTw2ll6w==
+"@coral-xyz/anchor-errors@^0.30.1":
+  version "0.30.1"
+  resolved "https://registry.yarnpkg.com/@coral-xyz/anchor-errors/-/anchor-errors-0.30.1.tgz#bdfd3a353131345244546876eb4afc0e125bec30"
+  integrity sha512-9Mkradf5yS5xiLWrl9WrpjqOrAV+/W2RQHDlbnAZBivoGpOs1ECjoDCkVk4aRG8ZdiFiB8zQEVlxf+8fKkmSfQ==
 
-"@coral-xyz/anchor@^0.31.0":
-  version "0.31.0"
-  resolved "https://registry.yarnpkg.com/@coral-xyz/anchor/-/anchor-0.31.0.tgz#76b84541e6fdfbd6c661584cdc418453a6416f12"
-  integrity sha512-Yb1NwP1s4cWhAw7wL7vOLHSWWw3cD5D9pRCVSeJpdqPaI+w7sfRLScnVJL6ViYMZynB7nAG/5HcUPKUnY0L9rw==
+"@coral-xyz/anchor@^0.30.1":
+  version "0.30.1"
+  resolved "https://registry.yarnpkg.com/@coral-xyz/anchor/-/anchor-0.30.1.tgz#17f3e9134c28cd0ea83574c6bab4e410bcecec5d"
+  integrity sha512-gDXFoF5oHgpriXAaLpxyWBHdCs8Awgf/gLHIo6crv7Aqm937CNdY+x+6hoj7QR5vaJV7MxWSQ0NGFzL3kPbWEQ==
   dependencies:
-    "@coral-xyz/anchor-errors" "^0.31.0"
-    "@coral-xyz/borsh" "^0.31.0"
+    "@coral-xyz/anchor-errors" "^0.30.1"
+    "@coral-xyz/borsh" "^0.30.1"
     "@noble/hashes" "^1.3.1"
-    "@solana/web3.js" "^1.69.0"
+    "@solana/web3.js" "^1.68.0"
     bn.js "^5.1.2"
     bs58 "^4.0.1"
     buffer-layout "^1.2.2"
     camelcase "^6.3.0"
     cross-fetch "^3.1.5"
+    crypto-hash "^1.3.0"
     eventemitter3 "^4.0.7"
     pako "^2.0.3"
+    snake-case "^3.0.4"
     superstruct "^0.15.4"
     toml "^3.0.0"
 
-"@coral-xyz/borsh@^0.31.0":
-  version "0.31.0"
-  resolved "https://registry.yarnpkg.com/@coral-xyz/borsh/-/borsh-0.31.0.tgz#eb77239b75f3ea9e771b1ee0821712caf664cb32"
-  integrity sha512-DwdQ5fuj+rGQCTKRnxnW1W2lvcpBaFc9m9M1TcGGlm+bwCcggmDgbLKLgF+LjIrKnc7Nd+bCACx5RA9YTK2I4Q==
+"@coral-xyz/borsh@^0.30.1":
+  version "0.30.1"
+  resolved "https://registry.yarnpkg.com/@coral-xyz/borsh/-/borsh-0.30.1.tgz#869d8833abe65685c72e9199b8688477a4f6b0e3"
+  integrity sha512-aaxswpPrCFKl8vZTbxLssA2RvwX2zmKLlRCIktJOwW+VpVwYtXRtlWiIP+c2pPRKneiTiWCN2GEMSH9j1zTlWQ==
   dependencies:
     bn.js "^5.1.2"
     buffer-layout "^1.2.0"
@@ -60,7 +62,7 @@
   dependencies:
     buffer "~6.0.3"
 
-"@solana/web3.js@^1.69.0":
+"@solana/web3.js@^1.68.0":
   version "1.98.0"
   resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.98.0.tgz#21ecfe8198c10831df6f0cfde7f68370d0405917"
   integrity sha512-nz3Q5OeyGFpFCR+erX2f6JPt3sKhzhYcSycBCSPkWjzSVDh/Rr1FqTVMRe58FKO16/ivTUcuJjeS5MyBvpkbzA==
@@ -396,6 +398,11 @@ cross-fetch@^3.1.5:
   dependencies:
     node-fetch "^2.7.0"
 
+crypto-hash@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/crypto-hash/-/crypto-hash-1.3.0.tgz#b402cb08f4529e9f4f09346c3e275942f845e247"
+  integrity sha512-lyAZ0EMyjDkVvz8WOeVnuCPvKVBXcMv1l5SVqO1yC7PzTwrD/pPje/BIRbWhMoPe436U+Y2nD7f5bFx0kt+Sbg==
+
 debug@4.3.3:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
@@ -429,6 +436,14 @@ diff@^3.1.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
+
+dot-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/dot-case/-/dot-case-3.0.4.tgz#9b2b670d00a431667a8a75ba29cd1b98809ce751"
+  integrity sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -694,6 +709,13 @@ loupe@^2.3.6:
   dependencies:
     get-func-name "^2.0.1"
 
+lower-case@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.2.tgz#6fa237c63dbdc4a82ca0fd882e4722dc5e634e28"
+  integrity sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==
+  dependencies:
+    tslib "^2.0.3"
+
 make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
@@ -769,6 +791,14 @@ nanoid@3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.1.tgz#6347a18cac88af88f58af0b3594b723d5e99bb35"
   integrity sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==
+
+no-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.4.tgz#d361fd5c9800f558551a8369fc0dcd4662b6124d"
+  integrity sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==
+  dependencies:
+    lower-case "^2.0.2"
+    tslib "^2.0.3"
 
 node-fetch@^2.7.0:
   version "2.7.0"
@@ -889,6 +919,14 @@ serialize-javascript@6.0.0:
   integrity sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==
   dependencies:
     randombytes "^2.1.0"
+
+snake-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/snake-case/-/snake-case-3.0.4.tgz#4f2bbd568e9935abdfd593f34c691dadb49c452c"
+  integrity sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==
+  dependencies:
+    dot-case "^3.0.4"
+    tslib "^2.0.3"
 
 source-map-support@^0.5.6:
   version "0.5.21"
@@ -1013,7 +1051,7 @@ tsconfig-paths@^3.5.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^2.8.0:
+tslib@^2.0.3, tslib@^2.8.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==


### PR DESCRIPTION
this PR adds tests that we need to fulfill for initialize / deposit, lp is added too but optional to fulfill for now. it also adds two crates for the programs we're going to be cpi'ing into with clean definitions of the params for cpi calls and types used. 

it also rolls us back to 0.30.1. orca does not have published examples for how to interact with their program using 0.31.0 and i don't want to eat that dog food right now. i reached out to orca team in dms and yugure is going to let me know when they've added it to their cpi samples repo